### PR TITLE
feat: update documentation to use New instead of NewClient

### DIFF
--- a/docs/examples/bot-messages-which-self-delete.md
+++ b/docs/examples/bot-messages-which-self-delete.md
@@ -44,12 +44,9 @@ func autoDeleteNewMessages(session disgord.Session, evt *disgord.MessageCreate) 
 }
 
 func main() {
-	client, err := disgord.NewClient(&disgord.Config{
+	client := disgord.New(&disgord.Config{
 		BotToken: os.Getenv("DISGORD_TOKEN"),
 	})
-	if err != nil {
-		panic(err)
-	}
 
 	client.On(disgord.EventMessageCreate, autoDeleteNewMessages)
 

--- a/docs/examples/bot-messages-which-self-delete.md
+++ b/docs/examples/bot-messages-which-self-delete.md
@@ -46,6 +46,7 @@ func autoDeleteNewMessages(session disgord.Session, evt *disgord.MessageCreate) 
 func main() {
 	client := disgord.New(&disgord.Config{
 		BotToken: os.Getenv("DISGORD_TOKEN"),
+		Logger: disgord.DefaultLogger(false), // optional logging, debug=false
 	})
 
 	client.On(disgord.EventMessageCreate, autoDeleteNewMessages)

--- a/docs/examples/connect-through-a-proxy.md
+++ b/docs/examples/connect-through-a-proxy.md
@@ -20,6 +20,7 @@ func main() {
 	client := disgord.New(&disgord.Config{
 		BotToken: os.Getenv("DISGORD_TOKEN"),
 		Proxy: p, // Anything satisfying the proxy.Dialer interface will work
+		Logger: disgord.DefaultLogger(false), // optional logging, debug=false
 	})
 
 	if err := client.Connect(); err != nil {

--- a/docs/examples/connect-through-a-proxy.md
+++ b/docs/examples/connect-through-a-proxy.md
@@ -17,13 +17,10 @@ func main() {
 		panic(err)
 	}
 	
-	client, err := disgord.NewClient(&disgord.Config{
+	client := disgord.New(&disgord.Config{
 		BotToken: os.Getenv("DISGORD_TOKEN"),
 		Proxy: p, // Anything satisfying the proxy.Dialer interface will work
 	})
-	if err != nil {
-		panic(err)
-	}
 
 	if err := client.Connect(); err != nil {
 		panic(err)

--- a/docs/examples/connecting-to-voice.md
+++ b/docs/examples/connecting-to-voice.md
@@ -15,7 +15,7 @@ import (
 
 func main() {
 	// Set up a new Disgord client
-	discord, _ := disgord.NewClient(&disgord.Config{
+	discord := disgord.New(&disgord.Config{
 		BotToken: os.Getenv("DISGORD_TOKEN"),
 	})
 

--- a/docs/examples/connecting-to-voice.md
+++ b/docs/examples/connecting-to-voice.md
@@ -17,6 +17,7 @@ func main() {
 	// Set up a new Disgord client
 	discord := disgord.New(&disgord.Config{
 		BotToken: os.Getenv("DISGORD_TOKEN"),
+		Logger: disgord.DefaultLogger(false), // optional logging, debug=false
 	})
 
 	var voice disgord.VoiceConnection

--- a/docs/examples/enforce-temporary-member-messages.md
+++ b/docs/examples/enforce-temporary-member-messages.md
@@ -28,12 +28,9 @@ func autoDeleteNewMessages(session disgord.Session, evt *disgord.MessageCreate) 
 }
 
 func main() {
-	client, err := disgord.NewClient(&disgord.Config{
+	client := disgord.New(&disgord.Config{
 		BotToken: os.Getenv("DISGORD_TOKEN"),
 	})
-	if err != nil {
-		panic(err)
-	}
 
 	client.On(disgord.EventMessageCreate, autoDeleteNewMessages)
 

--- a/docs/examples/enforce-temporary-member-messages.md
+++ b/docs/examples/enforce-temporary-member-messages.md
@@ -30,6 +30,7 @@ func autoDeleteNewMessages(session disgord.Session, evt *disgord.MessageCreate) 
 func main() {
 	client := disgord.New(&disgord.Config{
 		BotToken: os.Getenv("DISGORD_TOKEN"),
+		Logger: disgord.DefaultLogger(false), // optional logging, debug=false
 	})
 
 	client.On(disgord.EventMessageCreate, autoDeleteNewMessages)

--- a/docs/examples/listen-for-messages.md
+++ b/docs/examples/listen-for-messages.md
@@ -3,12 +3,9 @@
 In Disgord it is required that you specify the event you are listening to using an event key (see package event). Unlike discordgo this library does not use reflection to understand which event type your function reacts to.
 ```go
 
-client, err := disgord.NewClient(&disgord.Config{
+client := disgord.New(&disgord.Config{
     BotToken: os.Getenv("DISGORD_TOKEN"),
 })
-if err != nil {
-    panic(err)
-}
 
 // create a handler and bind it to new message events
 // handlers/listener are run in sequence if you register more than one
@@ -37,12 +34,9 @@ session.On(event.MessageCreate, func(session disgord.Session, data *disgord.Mess
 
 In addition, Disgord also supports the use of channels for handling events. It is extremely important that you remember to tell disgord which events you want, before you start using channels. Failure to do so may result in the desired events being discarded at the socket layer, as you did not notify you wanted them. See the code example below.
 ```go
-client, err := disgord.NewClient(&disgord.Config{
+client := disgord.New(&disgord.Config{
     BotToken: os.Getenv("DISGORD_TOKEN"),
 })
-if err != nil {
-    panic(err)
-}
 
 // or use a channel to listen for events
 go func() {

--- a/docs/examples/listen-for-messages.md
+++ b/docs/examples/listen-for-messages.md
@@ -5,6 +5,7 @@ In Disgord it is required that you specify the event you are listening to using 
 
 client := disgord.New(&disgord.Config{
     BotToken: os.Getenv("DISGORD_TOKEN"),
+    Logger: disgord.DefaultLogger(false), // optional logging, debug=false
 })
 
 // create a handler and bind it to new message events
@@ -36,6 +37,7 @@ In addition, Disgord also supports the use of channels for handling events. It i
 ```go
 client := disgord.New(&disgord.Config{
     BotToken: os.Getenv("DISGORD_TOKEN"),
+    Logger: disgord.DefaultLogger(false), // optional logging, debug=false
 })
 
 // or use a channel to listen for events

--- a/docs/examples/ping-pong-bot.md
+++ b/docs/examples/ping-pong-bot.md
@@ -4,12 +4,9 @@ So the time has come where you want to be a bot engineer huh? In this article yo
 
 ```go
 // create a Disgord session
-client, err := disgord.NewClient(&disgord.Config{
+client := disgord.New(&disgord.Config{
     BotToken: os.Getenv("DISGORD_TOKEN"),
 })
-if err != nil {
-    panic(err)
-}
 
 // create a handler and bind it to new message events
 client.On(disgord.EventMessageCreate, func(session disgord.Session, data *disgord.MessageCreate) {

--- a/docs/examples/ping-pong-bot.md
+++ b/docs/examples/ping-pong-bot.md
@@ -6,6 +6,7 @@ So the time has come where you want to be a bot engineer huh? In this article yo
 // create a Disgord session
 client := disgord.New(&disgord.Config{
     BotToken: os.Getenv("DISGORD_TOKEN"),
+    Logger: disgord.DefaultLogger(false), // optional logging, debug=false
 })
 
 // create a handler and bind it to new message events

--- a/docs/examples/sharding.md
+++ b/docs/examples/sharding.md
@@ -6,7 +6,7 @@ DisGord uses an internal shard manager to handle this for you. However, you are 
 
 # Enforce N number of shards
 ```go
-client := disgord.NewClient(&disgord.Config{
+client := disgord.New(&disgord.Config{
     WSShardManagerConfig: &disgord.WSShardManagerConfig{
         // If you have another instance running with shards 0-3, and want this instance to use the range 4-8
         // you can specify the number of the first shard this instance should have. Otherwise there is no
@@ -34,7 +34,7 @@ The entire shard config is optional as your bot will always use sharding by defa
 
 ```go
 // this client is also using shards
-client := disgord.NewClient(&disgord.Config{
+client := disgord.New(&disgord.Config{
     BotToken: "random token",
 })
 ```

--- a/docs/examples/sharding.md
+++ b/docs/examples/sharding.md
@@ -27,6 +27,7 @@ client := disgord.New(&disgord.Config{
         URL: "",
     },
     BotToken: "random token",
+    Logger: disgord.DefaultLogger(false), // optional logging, debug=false
 })
 ```
 
@@ -36,5 +37,6 @@ The entire shard config is optional as your bot will always use sharding by defa
 // this client is also using shards
 client := disgord.New(&disgord.Config{
     BotToken: "random token",
+    Logger: disgord.DefaultLogger(false), // optional logging, debug=false
 })
 ```


### PR DESCRIPTION
# Description

Changes all examples in the documentation to use disgord.New instead of discord.NewClient as all the implementations with NewClient either discarded the error or panicked with it anyway.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Added benchmarks if this is a performant required component (potential bottlenecks)
