### PR TITLE
Fixes references to Evt* objects

### DIFF
--- a/disgord.go
+++ b/disgord.go
@@ -36,7 +36,7 @@
 // Listen for events using channels
 //
 // Disgord also provides the option to listen for events using a channel, instead of registering a handler. However, before using the event channel, you must notify disgord that you care about the event (this is done automatically in the event handler registration).
-//  session.AcceptEvent(event.MessageCreate) // alternative: disgord.EventMessageCreate
+//  session.AcceptEvent(event.MessageCreate) // alternative: disgord.EvtMessageCreate
 //  session.AcceptEvent(event.MessageUpdate)
 //  for {
 //      var message *disgord.Message

--- a/docs/examples/bot-messages-which-self-delete.md
+++ b/docs/examples/bot-messages-which-self-delete.md
@@ -49,7 +49,7 @@ func main() {
 		Logger: disgord.DefaultLogger(false), // optional logging, debug=false
 	})
 
-	client.On(disgord.EventMessageCreate, autoDeleteNewMessages)
+	client.On(disgord.EvtMessageCreate, autoDeleteNewMessages)
 
 	// connect to the discord gateway to receive events
 	if err = client.Connect(); err != nil {

--- a/docs/examples/enforce-temporary-member-messages.md
+++ b/docs/examples/enforce-temporary-member-messages.md
@@ -33,7 +33,7 @@ func main() {
 		Logger: disgord.DefaultLogger(false), // optional logging, debug=false
 	})
 
-	client.On(disgord.EventMessageCreate, autoDeleteNewMessages)
+	client.On(disgord.EvtMessageCreate, autoDeleteNewMessages)
 
 	// connect to the discord gateway to receive events
 	err = client.Connect()

--- a/docs/examples/listen-for-messages.md
+++ b/docs/examples/listen-for-messages.md
@@ -12,7 +12,7 @@ client := disgord.New(&disgord.Config{
 // handlers/listener are run in sequence if you register more than one
 // so you should not need to worry about locking your objects unless you do any
 // parallel computing with said objects
-client.On(disgord.EventMessageCreate, func(session disgord.Session, data *disgord.MessageCreate) {
+client.On(disgord.EvtMessageCreate, func(session disgord.Session, data *disgord.MessageCreate) {
     fmt.Println(data.Message.Content)
 })
 
@@ -26,7 +26,7 @@ if err != nil {
 client.DisconnectOnInterrupt()
 ```
 
-Note that if you dislike the long `disgord.EventMessageCreate` name. You can use the sub package `event`. However, the `event` package will only hold valid Discord events.
+Note that if you dislike the long `disgord.EvtMessageCreate` name. You can use the sub package `event`. However, the `event` package will only hold valid Discord events.
 ```go 
 session.On(event.MessageCreate, func(session disgord.Session, data *disgord.MessageCreate) {
     fmt.Println(data.Message.Content)

--- a/docs/examples/ping-pong-bot.md
+++ b/docs/examples/ping-pong-bot.md
@@ -19,7 +19,7 @@ func main() {
     defer client.StayConnectedUntilInterrupted()
     
     // create a handler and bind it to new message events
-    client.On(disgord.EventMessageCreate, func(session disgord.Session, evt *disgord.MessageCreate) {
+    client.On(disgord.EvtMessageCreate, func(session disgord.Session, evt *disgord.MessageCreate) {
         msg := evt.Message
         if msg.Content == "ping" {
             _, _ = msg.RespondString(session, "pong")
@@ -41,7 +41,7 @@ import (
 	"os"
 )
 
-const NewMessage = disgord.EventMessageCreate
+const NewMessage = disgord.EvtMessageCreate
 
 func main() {
     // configure a DisGord client

--- a/events_gen.go
+++ b/events_gen.go
@@ -11,7 +11,7 @@ import (
 
 // ---------------------------
 
-// EventChannelCreate Sent when a new channel is created, relevant to the current user. The inner payload is a DM channel or
+// EvtChannelCreate Sent when a new channel is created, relevant to the current user. The inner payload is a DM channel or
 // guild channel object.
 //
 const EvtChannelCreate = event.ChannelCreate
@@ -21,7 +21,7 @@ func (h *ChannelCreate) setShardID(id uint)                  { h.ShardID = id }
 
 // ---------------------------
 
-// EventChannelDelete Sent when a channel relevant to the current user is deleted. The inner payload is a DM or Guild channel object.
+// EvtChannelDelete Sent when a channel relevant to the current user is deleted. The inner payload is a DM or Guild channel object.
 //
 const EvtChannelDelete = event.ChannelDelete
 
@@ -30,7 +30,7 @@ func (h *ChannelDelete) setShardID(id uint)                  { h.ShardID = id }
 
 // ---------------------------
 
-// EventChannelPinsUpdate Sent when a message is pinned or unpinned in a text channel. This is not sent when a pinned message is deleted.
+// EvtChannelPinsUpdate Sent when a message is pinned or unpinned in a text channel. This is not sent when a pinned message is deleted.
 //  Fields:
 //  - ChannelID int64 or Snowflake
 //  - LastPinTimestamp time.Now().UTC().Format(time.RFC3339)
@@ -43,7 +43,7 @@ func (h *ChannelPinsUpdate) setShardID(id uint)                  { h.ShardID = i
 
 // ---------------------------
 
-// EventChannelUpdate Sent when a channel is updated. The inner payload is a guild channel object.
+// EvtChannelUpdate Sent when a channel is updated. The inner payload is a guild channel object.
 //
 const EvtChannelUpdate = event.ChannelUpdate
 
@@ -52,7 +52,7 @@ func (h *ChannelUpdate) setShardID(id uint)                  { h.ShardID = id }
 
 // ---------------------------
 
-// EventGuildBanAdd Sent when a user is banned from a guild. The inner payload is a user object, with an extra guild_id key.
+// EvtGuildBanAdd Sent when a user is banned from a guild. The inner payload is a user object, with an extra guild_id key.
 //
 const EvtGuildBanAdd = event.GuildBanAdd
 
@@ -61,7 +61,7 @@ func (h *GuildBanAdd) setShardID(id uint)                  { h.ShardID = id }
 
 // ---------------------------
 
-// EventGuildBanRemove Sent when a user is unbanned from a guild. The inner payload is a user object, with an extra guild_id key.
+// EvtGuildBanRemove Sent when a user is unbanned from a guild. The inner payload is a user object, with an extra guild_id key.
 //
 const EvtGuildBanRemove = event.GuildBanRemove
 
@@ -70,7 +70,7 @@ func (h *GuildBanRemove) setShardID(id uint)                  { h.ShardID = id }
 
 // ---------------------------
 
-// EventGuildCreate This event can be sent in three different scenarios:
+// EvtGuildCreate This event can be sent in three different scenarios:
 //  1. When a user is initially connecting, to lazily load and backfill information for all unavailable guilds
 //     sent in the Ready event.
 // 	2. When a Guild becomes available again to the client.
@@ -83,7 +83,7 @@ func (h *GuildCreate) setShardID(id uint)                  { h.ShardID = id }
 
 // ---------------------------
 
-// EventGuildDelete Sent when a guild becomes unavailable during a guild outage, or when the user leaves or is removed from a guild.
+// EvtGuildDelete Sent when a guild becomes unavailable during a guild outage, or when the user leaves or is removed from a guild.
 // The inner payload is an unavailable guild object. If the unavailable field is not set, the user was removed
 // from the guild.
 //
@@ -94,7 +94,7 @@ func (h *GuildDelete) setShardID(id uint)                  { h.ShardID = id }
 
 // ---------------------------
 
-// EventGuildEmojisUpdate Sent when a guild's emojis have been updated.
+// EvtGuildEmojisUpdate Sent when a guild's emojis have been updated.
 //  Fields:
 //  - GuildID Snowflake
 //  - Emojis []*Emoji
@@ -106,7 +106,7 @@ func (h *GuildEmojisUpdate) setShardID(id uint)                  { h.ShardID = i
 
 // ---------------------------
 
-// EventGuildIntegrationsUpdate Sent when a guild integration is updated.
+// EvtGuildIntegrationsUpdate Sent when a guild integration is updated.
 //  Fields:
 //  - GuildID Snowflake
 //
@@ -117,7 +117,7 @@ func (h *GuildIntegrationsUpdate) setShardID(id uint)                  { h.Shard
 
 // ---------------------------
 
-// EventGuildMemberAdd Sent when a new user joins a guild. The inner payload is a guild member object with these extra fields:
+// EvtGuildMemberAdd Sent when a new user joins a guild. The inner payload is a guild member object with these extra fields:
 //  - GuildID Snowflake
 //
 //  Fields:
@@ -130,7 +130,7 @@ func (h *GuildMemberAdd) setShardID(id uint)                  { h.ShardID = id }
 
 // ---------------------------
 
-// EventGuildMemberRemove Sent when a user is removed from a guild (leave/kick/ban).
+// EvtGuildMemberRemove Sent when a user is removed from a guild (leave/kick/ban).
 //  Fields:
 //  - GuildID   Snowflake
 //  - User      *User
@@ -142,7 +142,7 @@ func (h *GuildMemberRemove) setShardID(id uint)                  { h.ShardID = i
 
 // ---------------------------
 
-// EventGuildMemberUpdate Sent when a guild member is updated.
+// EvtGuildMemberUpdate Sent when a guild member is updated.
 //  Fields:
 //  - GuildID   Snowflake
 //  - Roles     []Snowflake
@@ -156,7 +156,7 @@ func (h *GuildMemberUpdate) setShardID(id uint)                  { h.ShardID = i
 
 // ---------------------------
 
-// EventGuildMembersChunk Sent in response to Gateway Request Guild Members.
+// EvtGuildMembersChunk Sent in response to Gateway Request Guild Members.
 //  Fields:
 //  - GuildID Snowflake
 //  - Members []*Member
@@ -168,7 +168,7 @@ func (h *GuildMembersChunk) setShardID(id uint)                  { h.ShardID = i
 
 // ---------------------------
 
-// EventGuildRoleCreate Sent when a guild role is created.
+// EvtGuildRoleCreate Sent when a guild role is created.
 //  Fields:
 //  - GuildID   Snowflake
 //  - Role      *Role
@@ -180,7 +180,7 @@ func (h *GuildRoleCreate) setShardID(id uint)                  { h.ShardID = id 
 
 // ---------------------------
 
-// EventGuildRoleDelete Sent when a guild role is created.
+// EvtGuildRoleDelete Sent when a guild role is created.
 //  Fields:
 //  - GuildID Snowflake
 //  - RoleID  Snowflake
@@ -192,7 +192,7 @@ func (h *GuildRoleDelete) setShardID(id uint)                  { h.ShardID = id 
 
 // ---------------------------
 
-// EventGuildRoleUpdate Sent when a guild role is created.
+// EvtGuildRoleUpdate Sent when a guild role is created.
 //  Fields:
 //  - GuildID Snowflake
 //  - Role    *Role
@@ -204,7 +204,7 @@ func (h *GuildRoleUpdate) setShardID(id uint)                  { h.ShardID = id 
 
 // ---------------------------
 
-// EventGuildUpdate Sent when a guild is updated. The inner payload is a guild object.
+// EvtGuildUpdate Sent when a guild is updated. The inner payload is a guild object.
 //
 const EvtGuildUpdate = event.GuildUpdate
 
@@ -213,7 +213,7 @@ func (h *GuildUpdate) setShardID(id uint)                  { h.ShardID = id }
 
 // ---------------------------
 
-// EventMessageCreate Sent when a message is created. The inner payload is a message object.
+// EvtMessageCreate Sent when a message is created. The inner payload is a message object.
 //
 const EvtMessageCreate = event.MessageCreate
 
@@ -222,7 +222,7 @@ func (h *MessageCreate) setShardID(id uint)                  { h.ShardID = id }
 
 // ---------------------------
 
-// EventMessageDelete Sent when a message is deleted.
+// EvtMessageDelete Sent when a message is deleted.
 //  Fields:
 //  - ID        Snowflake
 //  - ChannelID Snowflake
@@ -234,7 +234,7 @@ func (h *MessageDelete) setShardID(id uint)                  { h.ShardID = id }
 
 // ---------------------------
 
-// EventMessageDeleteBulk Sent when multiple messages are deleted at once.
+// EvtMessageDeleteBulk Sent when multiple messages are deleted at once.
 //  Fields:
 //  - IDs       []Snowflake
 //  - ChannelID Snowflake
@@ -246,7 +246,7 @@ func (h *MessageDeleteBulk) setShardID(id uint)                  { h.ShardID = i
 
 // ---------------------------
 
-// EventMessageReactionAdd Sent when a user adds a reaction to a message.
+// EvtMessageReactionAdd Sent when a user adds a reaction to a message.
 //  Fields:
 //  - UserID     Snowflake
 //  - ChannelID  Snowflake
@@ -260,7 +260,7 @@ func (h *MessageReactionAdd) setShardID(id uint)                  { h.ShardID = 
 
 // ---------------------------
 
-// EventMessageReactionRemove Sent when a user removes a reaction from a message.
+// EvtMessageReactionRemove Sent when a user removes a reaction from a message.
 //  Fields:
 //  - UserID     Snowflake
 //  - ChannelID  Snowflake
@@ -274,7 +274,7 @@ func (h *MessageReactionRemove) setShardID(id uint)                  { h.ShardID
 
 // ---------------------------
 
-// EventMessageReactionRemoveAll Sent when a user explicitly removes all reactions from a message.
+// EvtMessageReactionRemoveAll Sent when a user explicitly removes all reactions from a message.
 //  Fields:
 //  - ChannelID Snowflake
 //  - MessageID Snowflake
@@ -286,7 +286,7 @@ func (h *MessageReactionRemoveAll) setShardID(id uint)                  { h.Shar
 
 // ---------------------------
 
-// EventMessageUpdate Sent when a message is updated. The inner payload is a message object.
+// EvtMessageUpdate Sent when a message is updated. The inner payload is a message object.
 //
 // NOTE! Has _at_least_ the GuildID and ChannelID fields.
 //
@@ -297,7 +297,7 @@ func (h *MessageUpdate) setShardID(id uint)                  { h.ShardID = id }
 
 // ---------------------------
 
-// EventPresenceUpdate A user's presence is their current state on a guild. This event is sent when a user's presence is updated for a guild.
+// EvtPresenceUpdate A user's presence is their current state on a guild. This event is sent when a user's presence is updated for a guild.
 //  Fields:
 //  - User    *User
 //  - Roles   []Snowflake
@@ -312,7 +312,7 @@ func (h *PresenceUpdate) setShardID(id uint)                  { h.ShardID = id }
 
 // ---------------------------
 
-// EventPresencesReplace Holds and array of presence update objects
+// EvtPresencesReplace Holds and array of presence update objects
 //
 const EvtPresencesReplace = event.PresencesReplace
 
@@ -321,7 +321,7 @@ func (h *PresencesReplace) setShardID(id uint)                  { h.ShardID = id
 
 // ---------------------------
 
-// EventReady The ready event is dispatched when a client has completed the initial handshake with the gateway (for new sessions).
+// EvtReady The ready event is dispatched when a client has completed the initial handshake with the gateway (for new sessions).
 // // The ready event can be the largest and most complex event the gateway will send, as it contains all the state
 // // required for a client to begin interacting with the rest of the platform.
 // //  Fields:
@@ -339,7 +339,7 @@ func (h *Ready) setShardID(id uint)                  { h.ShardID = id }
 
 // ---------------------------
 
-// EventResumed The resumed event is dispatched when a client has sent a resume payload to the gateway
+// EvtResumed The resumed event is dispatched when a client has sent a resume payload to the gateway
 // (for resuming existing sessions).
 //  Fields:
 //  - Trace []string
@@ -351,7 +351,7 @@ func (h *Resumed) setShardID(id uint)                  { h.ShardID = id }
 
 // ---------------------------
 
-// EventTypingStart Sent when a user starts typing in a channel.
+// EvtTypingStart Sent when a user starts typing in a channel.
 //  Fields:
 //  - ChannelID     Snowflake
 //  - UserID        Snowflake
@@ -364,7 +364,7 @@ func (h *TypingStart) setShardID(id uint)                  { h.ShardID = id }
 
 // ---------------------------
 
-// EventUserUpdate Sent when properties about the user change. Inner payload is a user object.
+// EvtUserUpdate Sent when properties about the user change. Inner payload is a user object.
 //
 const EvtUserUpdate = event.UserUpdate
 
@@ -373,7 +373,7 @@ func (h *UserUpdate) setShardID(id uint)                  { h.ShardID = id }
 
 // ---------------------------
 
-// EventVoiceServerUpdate Sent when a guild's voice server is updated. This is sent when initially connecting to voice, and when the current
+// EvtVoiceServerUpdate Sent when a guild's voice server is updated. This is sent when initially connecting to voice, and when the current
 // voice instance fails over to a new server.
 //  Fields:
 //  - Token     string
@@ -387,7 +387,7 @@ func (h *VoiceServerUpdate) setShardID(id uint)                  { h.ShardID = i
 
 // ---------------------------
 
-// EventVoiceStateUpdate Sent when someone joins/leaves/moves voice channels. Inner payload is a voice state object.
+// EvtVoiceStateUpdate Sent when someone joins/leaves/moves voice channels. Inner payload is a voice state object.
 //
 const EvtVoiceStateUpdate = event.VoiceStateUpdate
 
@@ -396,7 +396,7 @@ func (h *VoiceStateUpdate) setShardID(id uint)                  { h.ShardID = id
 
 // ---------------------------
 
-// EventWebhooksUpdate Sent when a guild channel's webhook is created, updated, or deleted.
+// EvtWebhooksUpdate Sent when a guild channel's webhook is created, updated, or deleted.
 //  Fields:
 //  - GuildID   Snowflake
 //  - ChannelID Snowflake

--- a/generate/events/main.go
+++ b/generate/events/main.go
@@ -135,5 +135,5 @@ func (e eventName) RenderDocs() string {
 		return ""
 	}
 
-	return "// Event" + strings.Replace(*e.Docs, "\n", "\n// ", -1)
+	return "// Evt" + strings.Replace(*e.Docs, "\n", "\n// ", -1)
 }


### PR DESCRIPTION
# Description

Updates references to Evt* objects (which used to be Event*). Includes changes to events_gen.go that get overwritten when running `go generate`; @andersfylling if you want to point me to where I can make the relevant changes so they're not overwritten, I can do so.

## Type of change

- [x] Documentation

# Checklist:

- [ ] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
