### PR TITLE
specify events to ignore rather than handle

### DIFF
--- a/client.go
+++ b/client.go
@@ -379,22 +379,6 @@ func (c *Client) Connect() (err error) {
 		return err
 	}
 
-	// if both typing event and presence event are to be ignore, we can disable GuildSubscription
-	// https://discordapp.com/developers/docs/topics/gateway#guild-subscriptions
-	guildSubRequirements := []string{
-		EvtTypingStart, EvtPresenceUpdate,
-	}
-	for i := range c.config.IgnoreEvents {
-		evt := c.config.IgnoreEvents[i]
-		for j := range guildSubRequirements {
-			if evt == guildSubRequirements[j] {
-				// remove matched requirements
-				guildSubRequirements = append(guildSubRequirements[:j], guildSubRequirements[j+1:]...)
-				break
-			}
-		}
-	}
-
 	sharding := websocket.NewShardMngr(websocket.ShardManagerConfig{
 		ShardConfig:        c.config.ShardConfig,
 		Logger:             c.config.Logger,
@@ -405,7 +389,6 @@ func (c *Client) Connect() (err error) {
 		DisgordInfo:        LibraryInfo(),
 		ProjectName:        c.config.ProjectName,
 		BotToken:           c.config.BotToken,
-		GuildSubscriptions: len(guildSubRequirements) != 0,
 	})
 
 	c.setupConnectEnv()

--- a/reactor.go
+++ b/reactor.go
@@ -63,7 +63,7 @@ func demultiplexer(d *dispatcher, read <-chan *websocket.Event, cache *Cache) {
 
 		ctx := context.Background()
 		if err := populateResource(resource, ctx, evt); err != nil {
-			d.session.Logger().Error(err)
+			d.session.Logger().Error(err, "EVENT DATA: ", string(evt.Data))
 			continue // ignore event
 			// TODO: if an event is ignored, should it not at least send a signal for listeners with no parameters?
 		}

--- a/session.go
+++ b/session.go
@@ -53,11 +53,6 @@ type SocketHandler interface {
 	On(event string, inputs ...interface{})
 
 	Emitter
-
-	// event register (which events to accept)
-	// events which are not registered are discarded at socket level
-	// to increase performance
-	AcceptEvent(events ...string)
 }
 
 // AuditLogsRESTer REST interface for all audit-logs endpoints

--- a/websocket/eventclient_test.go
+++ b/websocket/eventclient_test.go
@@ -76,45 +76,6 @@ func (g *testWS) Disconnected() bool {
 
 var _ Conn = (*testWS)(nil)
 
-func TestManager_RegisterEvent(t *testing.T) {
-	m := EvtClient{
-		trackedEvents: &UniqueStringSlice{},
-	}
-	t1 := "test"
-	m.RegisterEvent(t1)
-
-	if m.trackedEvents.Len() == 0 {
-		t.Error("expected length to be 1, got 0")
-	}
-
-	m.RegisterEvent(t1)
-	if m.trackedEvents.Len() == 2 {
-		t.Error("expected length to be 1, got 2")
-	}
-}
-
-func TestManager_RemoveEvent(t *testing.T) {
-	m := EvtClient{
-		trackedEvents: &UniqueStringSlice{},
-	}
-	t1 := "test"
-	m.RegisterEvent(t1)
-
-	if m.trackedEvents.Len() == 0 {
-		t.Error("expected length to be 1, got 0")
-	}
-
-	m.RemoveEvent("sdfsdf")
-	if m.trackedEvents.Len() == 0 {
-		t.Error("expected length to be 1, got 0")
-	}
-
-	m.RemoveEvent(t1)
-	if m.trackedEvents.Len() == 1 {
-		t.Error("expected length to be 0, got 1")
-	}
-}
-
 // TODO: rewrite. EventClient now waits for a Ready event in the Connect method
 func TestEvtClient_communication(t *testing.T) {
 	deadline := 1 * time.Second

--- a/websocket/ratelimit.go
+++ b/websocket/ratelimit.go
@@ -17,17 +17,17 @@ func (s *UniqueStringSlice) Len() int {
 	return len(s.ids)
 }
 
-func (s *UniqueStringSlice) Exists(id string) bool {
+func (s *UniqueStringSlice) Contains(id string) (exists bool) {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	for i := range s.ids {
 		if id == s.ids[i] {
-			return true
+			exists = true
+			break
 		}
 	}
+	s.mu.RUnlock()
 
-	return false
+	return exists
 }
 func (s *UniqueStringSlice) Add(id string) {
 	s.mu.Lock()

--- a/websocket/sharding.go
+++ b/websocket/sharding.go
@@ -138,7 +138,7 @@ type ShardManagerConfig struct {
 	conn         Conn
 
 	// ...
-	TrackedEvents *UniqueStringSlice
+	IgnoreEvents []string
 
 	// sync ---
 	EventChan chan<- *Event
@@ -177,7 +177,7 @@ func (s *shardMngr) initializeShards() error {
 		Encoding:       constant.JSONEncoding,
 		Endpoint:       s.conf.URL,
 		Logger:         s.conf.Logger,
-		TrackedEvents:  s.conf.TrackedEvents,
+		IgnoreEvents:   s.conf.IgnoreEvents,
 		DiscordPktPool: s.DiscordPktPool,
 
 		// synchronization

--- a/websocket/sharding.go
+++ b/websocket/sharding.go
@@ -56,9 +56,9 @@ func ConfigureShardConfig(client GatewayBotGetter, conf *ShardConfig) error {
 	return nil
 }
 
-// ignoreGuildSubscriptions if both typing event and presence event are to be ignore, we can disable GuildSubscription
+// enableGuildSubscriptions if both typing event and presence event are to be ignore, we can disable GuildSubscription
 // https://discordapp.com/developers/docs/topics/gateway#guild-subscriptions
-func ignoreGuildSubscriptions(ignore []string) bool {
+func enableGuildSubscriptions(ignore []string) (updatedIgnores []string, ok bool) {
 	requires := []string{
 		event.TypingStart, event.PresenceUpdate,
 	}
@@ -74,12 +74,14 @@ func ignoreGuildSubscriptions(ignore []string) bool {
 			break
 		}
 	}
+	ok = len(requires) > 0
+	// TODO: remove unnecessary events from the ignore slice
 
-	return len(requires) == 0
+	return ignore, ok
 }
 
 func NewShardMngr(conf ShardManagerConfig) *shardMngr {
-	conf.GuildSubscriptions = ignoreGuildSubscriptions(conf.IgnoreEvents)
+	conf.IgnoreEvents, conf.GuildSubscriptions = enableGuildSubscriptions(conf.IgnoreEvents)
 
 	mngr := &shardMngr{
 		conf:   conf,

--- a/websocket/sharding_test.go
+++ b/websocket/sharding_test.go
@@ -2,6 +2,8 @@ package websocket
 
 import (
 	"testing"
+
+	"github.com/andersfylling/disgord/event"
 )
 
 type GatewayBotGetterMock struct {
@@ -59,6 +61,34 @@ func TestConfigureShardConfig(t *testing.T) {
 	}
 	if !conf.DisableAutoScaling {
 		t.Error("DisableAutoScaling should be true")
+	}
+}
+
+func TestEnableGuildSubscriptions(t *testing.T) {
+	ignore := []string{
+		event.TypingStart, event.PresenceUpdate,
+	}
+	if _, ok := enableGuildSubscriptions(ignore); ok {
+		t.Error("guild sub should be disabled")
+	}
+
+	ignore = []string{
+		event.TypingStart, event.PresenceUpdate, event.Ready,
+	}
+	if _, ok := enableGuildSubscriptions(ignore); ok {
+		t.Error("guild sub should be disabled")
+	}
+
+	ignore = []string{
+		event.TypingStart, event.Ready,
+	}
+	if _, ok := enableGuildSubscriptions(ignore); !ok {
+		t.Error("guild sub should be enabled")
+	}
+
+	ignore = []string{}
+	if _, ok := enableGuildSubscriptions(ignore); !ok {
+		t.Error("guild sub should be enabled")
 	}
 }
 


### PR DESCRIPTION
Previously, you defined which events you cared about. However, the caching logic interconnects way to extremely, such that very few events can ever be ignored if caching is enabled (which it always should be). 

It makes more sense to specify those few events that should be ignored instead.