### PR TITLE
correct the json key name for inline field

### DIFF
--- a/embed.go
+++ b/embed.go
@@ -346,8 +346,8 @@ func (c *EmbedFooter) CopyOverTo(other interface{}) (err error) {
 type EmbedField struct {
 	Lockable `json:"-"`
 
-	Name   string `json:"name"`           //  | , name of the field
-	Value  string `json:"value"`          //  | , value of the field
+	Name   string `json:"name"`             //  | , name of the field
+	Value  string `json:"value"`            //  | , value of the field
 	Inline bool   `json:"inline,omitempty"` // ?| , whether or not this field should display inline
 }
 

--- a/embed.go
+++ b/embed.go
@@ -348,7 +348,7 @@ type EmbedField struct {
 
 	Name   string `json:"name"`           //  | , name of the field
 	Value  string `json:"value"`          //  | , value of the field
-	Inline bool   `json:"bool,omitempty"` // ?| , whether or not this field should display inline
+	Inline bool   `json:"inline,omitempty"` // ?| , whether or not this field should display inline
 }
 
 // DeepCopy see interface at struct.go#DeepCopier


### PR DESCRIPTION
# Description
Correct the json key to be "inline" instead of "bool" for inline embed fields.

## Type of change
[x] Bug fix
