### PR TITLE
Use millisecond precision header

### DIFF
--- a/httd/client.go
+++ b/httd/client.go
@@ -161,9 +161,10 @@ func NewClient(conf *Config) (*Client, error) {
 	authorization := fmt.Sprintf(AuthorizationFormat, conf.BotToken)
 	userAgent := fmt.Sprintf(UserAgentFormat, conf.UserAgentSourceURL, conf.UserAgentVersion, conf.UserAgentExtra)
 	header := map[string][]string{
-		"Authorization":   {authorization},
-		"User-Agent":      {userAgent},
-		"Accept-Encoding": {"gzip"},
+		XRateLimitPrecision: {"millisecond"},
+		"Authorization":     {authorization},
+		"User-Agent":        {userAgent},
+		"Accept-Encoding":   {"gzip"},
 	}
 
 	return &Client{
@@ -205,7 +206,7 @@ type RateLimitAdjuster func(timeout time.Duration) time.Duration
 type Request struct {
 	Method            string
 	Ratelimiter       string
-	RateLimitAdjuster RateLimitAdjuster
+	RateLimitAdjuster RateLimitAdjuster // TODO: is this now redundant?
 	Endpoint          string
 	Body              interface{} // will automatically marshal to JSON if the ContentType is httd.ContentTypeJSON
 	ContentType       string

--- a/httd/ratelimit.go
+++ b/httd/ratelimit.go
@@ -10,6 +10,7 @@ import (
 
 // http rate limit identifiers
 const (
+	XRateLimitPrecision  = "X-RateLimit-Precision"
 	XRateLimitLimit      = "X-RateLimit-Limit"
 	XRateLimitRemaining  = "X-RateLimit-Remaining"
 	XRateLimitReset      = "X-RateLimit-Reset" // is converted from seconds to milliseconds!
@@ -85,11 +86,12 @@ func ExtractRateLimitInfo(resp *http.Response, body []byte) (info *RateLimitInfo
 	}
 	if resetStr != "" {
 		info.Empty = false
-		info.Reset, err = strconv.ParseInt(resetStr, 10, 64)
+		var seconds float64
+		seconds, err = strconv.ParseFloat(resetStr, 64)
 		if err != nil {
 			return
 		}
-		info.Reset *= 1000 // second => milliseconds
+		info.Reset = int64(seconds * 1000) // second => milliseconds: 3,453.234 => 3,453,234
 	}
 	if retryAfterStr != "" {
 		info.Empty = false

--- a/reaction.go
+++ b/reaction.go
@@ -3,7 +3,6 @@ package disgord
 import (
 	"errors"
 	"net/http"
-	"time"
 
 	"github.com/andersfylling/disgord/constant"
 	"github.com/andersfylling/disgord/endpoint"
@@ -58,13 +57,6 @@ func (r *Reaction) CopyOverTo(other interface{}) (err error) {
 	return
 }
 
-func reactionEndpointRLAdjuster(d time.Duration) time.Duration {
-	if d.Seconds() <= 2 { // the time diff is not accurate at all.. might be 1s or 2s.
-		d = time.Duration(250) * time.Millisecond // 1/250ms
-	}
-	return d
-}
-
 // CreateReaction [REST] Create a reaction for the message. This endpoint requires the 'READ_MESSAGE_HISTORY'
 // permission to be present on the current user. Additionally, if nobody else has reacted to the message using this
 // emoji, this endpoint requires the 'ADD_REACTIONS' permission to be present on the current user. Returns a 204 empty
@@ -100,10 +92,9 @@ func (c *Client) CreateReaction(channelID, messageID Snowflake, emoji interface{
 	}
 
 	r := c.newRESTRequest(&httd.Request{
-		Method:            http.MethodPut,
-		Ratelimiter:       ratelimitChannelMessages(channelID) + "/reactions",
-		Endpoint:          endpoint.ChannelMessageReactionMe(channelID, messageID, emojiCode),
-		RateLimitAdjuster: reactionEndpointRLAdjuster,
+		Method:      http.MethodPut,
+		Ratelimiter: ratelimitChannelMessages(channelID) + "/reactions",
+		Endpoint:    endpoint.ChannelMessageReactionMe(channelID, messageID, emojiCode),
 	}, flags)
 	r.expectsStatusCode = http.StatusNoContent
 
@@ -143,10 +134,9 @@ func (c *Client) DeleteOwnReaction(channelID, messageID Snowflake, emoji interfa
 	}
 
 	r := c.newRESTRequest(&httd.Request{
-		Method:            http.MethodDelete,
-		Ratelimiter:       ratelimitChannelMessages(channelID) + "/reactions",
-		Endpoint:          endpoint.ChannelMessageReactionMe(channelID, messageID, emojiCode),
-		RateLimitAdjuster: reactionEndpointRLAdjuster,
+		Method:      http.MethodDelete,
+		Ratelimiter: ratelimitChannelMessages(channelID) + "/reactions",
+		Endpoint:    endpoint.ChannelMessageReactionMe(channelID, messageID, emojiCode),
 	}, flags)
 	r.expectsStatusCode = http.StatusNoContent
 
@@ -186,10 +176,9 @@ func (c *Client) DeleteUserReaction(channelID, messageID, userID Snowflake, emoj
 	}
 
 	r := c.newRESTRequest(&httd.Request{
-		Method:            http.MethodDelete,
-		Ratelimiter:       ratelimitChannelMessages(channelID) + "/reactions",
-		Endpoint:          endpoint.ChannelMessageReactionUser(channelID, messageID, emojiCode, userID),
-		RateLimitAdjuster: reactionEndpointRLAdjuster,
+		Method:      http.MethodDelete,
+		Ratelimiter: ratelimitChannelMessages(channelID) + "/reactions",
+		Endpoint:    endpoint.ChannelMessageReactionUser(channelID, messageID, emojiCode, userID),
 	}, flags)
 	r.expectsStatusCode = http.StatusNoContent
 
@@ -242,9 +231,8 @@ func (c *Client) GetReaction(channelID, messageID Snowflake, emoji interface{}, 
 	}
 
 	r := c.newRESTRequest(&httd.Request{
-		Ratelimiter:       ratelimitChannelMessages(channelID) + "/reactions",
-		Endpoint:          endpoint.ChannelMessageReaction(channelID, messageID, emojiCode) + query,
-		RateLimitAdjuster: reactionEndpointRLAdjuster,
+		Ratelimiter: ratelimitChannelMessages(channelID) + "/reactions",
+		Endpoint:    endpoint.ChannelMessageReaction(channelID, messageID, emojiCode) + query,
 	}, flags)
 	r.factory = func() interface{} {
 		tmp := make([]*User, 0)


### PR DESCRIPTION
# Description
This introduces support for millisecond precision for the rate limit reset field. In addition the local rate limit adjusters for reactions are removed, such that disgord can use true rate limit values from discord.

Previously discord did not support millisecond precision such that these adjustments would have to be hardcoded. See more here: https://github.com/discordapp/discord-api-docs/pull/1064

I am unsure when discord will actually support these headers. So whenever I find that out I'll merge this.

fixes #158 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
