### PR TITLE
add DM check to Message

### DIFF
--- a/message.go
+++ b/message.go
@@ -133,6 +133,14 @@ func (m *Message) updateInternals() {
 	}
 }
 
+// DirectMessage checks if the message is from a direct message channel.
+//
+// WARNING! Note that, when fetching messages using the REST API the
+// guildID might be empty -> giving a false positive.
+func (m *Message) DirectMessage() bool {
+	return m.Type == MessageTypeDefault && m.GuildID.Empty()
+}
+
 // TODO: why is this method needed?
 //func (m *Message) MarshalJSON() ([]byte, error) {
 //	if m.ID.Empty() {


### PR DESCRIPTION
# Description

Adds a method to check if the message is from a direct message or a guild channel.

Fixes #153

## Type of change

- [x] New feature (non-breaking change which adds functionality)
