### PR TITLE
allow kicking member from voice channel (fixes #133)

### DIFF
--- a/client.go
+++ b/client.go
@@ -661,6 +661,10 @@ func (c *Client) GetGuilds(params *GetCurrentUserGuildsParams, flags ...Flag) ([
 	return c.GetCurrentUserGuilds(params)
 }
 
+func (c *Client) KickVoiceParticipant(guildID, userID Snowflake) error {
+	return c.UpdateGuildMember(guildID, userID).KickFromVoice().Execute()
+}
+
 // SendMsg Input anything and it will be converted to a message and sent. If you
 // supply it with multiple data's, it will simply merge them. Even if they are multiple Message objects.
 // However, if you supply multiple CreateMessageParams objects, you will face issues. But at this point

--- a/guild.go
+++ b/guild.go
@@ -1704,7 +1704,7 @@ func (c *Client) AddGuildMember(guildID, userID Snowflake, accessToken string, p
 	return member, err
 }
 
-// ModifyGuildMember [REST] Modify attributes of a guild member. Returns a 204 empty response on success.
+// UpdateGuildMember [REST] Modify attributes of a guild member. Returns a 204 empty response on success.
 // Fires a Guild Member Update Gateway event.
 //  Method                  PATCH
 //  Endpoint                /guilds/{guild.id}/members/{user.id}
@@ -2289,10 +2289,10 @@ type updateGuildMemberBuilder struct {
 	r RESTBuilder
 }
 
-// SetDefaultNick removes nickname for user. Requires permission MANAGE_NICKNAMES
-// deprecated: use DeleteNick()
-func (b *updateGuildMemberBuilder) SetDefaultNick() *updateGuildMemberBuilder {
-	return b.DeleteNick()
+// KickFromVoice kicks member out of voice channel. Assuming he/she/it is in one.
+func (b *updateGuildMemberBuilder) KickFromVoice() *updateGuildMemberBuilder {
+	b.r.param("channel_id", 0)
+	return b
 }
 
 // DeleteNick removes nickname for user. Requires permission MANAGE_NICKNAMES

--- a/session.go
+++ b/session.go
@@ -522,6 +522,8 @@ type Session interface {
 	// Custom REST functions
 	SendMsg(channelID Snowflake, data ...interface{}) (*Message, error)
 
+	KickVoiceParticipant(guildID, userID Snowflake) error
+
 	// Status update functions
 	UpdateStatus(s *UpdateStatusCommand) error
 	UpdateStatusString(s string) error


### PR DESCRIPTION
# Description

Updating members now allow for voice kicking. 
`client.UpdateGuildMember(guildID, userID).KickFromVoice().Exec()`
or
`client.KickVoiceParticipant(guildID, userID)`

Fixes #133 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I ran `go generate`
- [ ] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
