### PR TITLE
set minimum go version to 1.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/andersfylling/disgord
 
+go 1.12
+
 require (
 	github.com/andersfylling/snowflake/v4 v4.0.1
 	github.com/gorilla/websocket v1.4.0


### PR DESCRIPTION
# Description

This is required in order to switch to the new ws library.

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
