### PR TITLE
log timestamps when a identify is sent

### DIFF
--- a/websocket/metrics/timestamps.go
+++ b/websocket/metrics/timestamps.go
@@ -1,0 +1,46 @@
+package metrics
+
+import (
+	"sync"
+	"time"
+)
+
+type TimestampLogger interface {
+	LogTimestamp()
+}
+
+func NewTimestampLogger(limit uint) TimestampLogger {
+	return &timestampStack{
+		tms:   make([]time.Time, limit),
+		limit: limit,
+	}
+}
+
+type timestampStack struct {
+	sync.RWMutex
+	tms   []time.Time
+	index uint
+	limit uint
+}
+
+var _ TimestampLogger = (*timestampStack)(nil)
+
+func (s *timestampStack) shift() {
+	offset := uint(float32(s.index) * 0.2)
+	for i := uint(0); i < s.index; i++ {
+		s.tms[i] = s.tms[offset]
+		offset++
+	}
+	s.tms = s.tms[:s.index-offset]
+	s.index -= offset
+}
+
+func (s *timestampStack) LogTimestamp() {
+	s.Lock()
+	if s.index == s.limit {
+		s.shift()
+	}
+	s.tms[s.index] = time.Now()
+	s.index++
+	s.Unlock()
+}


### PR DESCRIPTION
# Description

Adds logging of timestamp for whenever an identify message is sent to the gateway.

TODO:
 - [ ] unit tests
 - [ ] zero overhead when deactivated

## Type of change

- [x] New feature (non-breaking change which adds functionality

# Checklist:

- [ ] I ran `go generate`
- [ ] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
