### PR TITLE
[br] auto-scaling on error + re-distributing message queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@
 
 ## About
 Go module for interacting with the Discord API. Supports events, REST calls and voice (sending only).
- 
-Discord object comes with helper functions such as `Message.Reply(session, "hello")`, or `Session.DeleteFromDiscord(role)` for simplicity/readability.
+
+The goal is to make bot development easy and handle some nastiness internally; sharding, auto-scaling of shards, caching, provide helper functions, middlewares for events, allow concurrent use of rate limiters, etc.
 
 DisGord has complete implementation for Discord's documented REST API. It lacks battle testing, so any bug report/feedback is greatly appreciated!
 
@@ -38,7 +38,7 @@ Talk to us on Discord! We exist in both the Gopher server and the Discord API se
  - [Discord API](https://discord.gg/HBTHbme)
 
 ## Warning
-The develop branch is under continuous breaking changes, as the interface and exported funcs/consts are still undergoing planning. Because DisGord is under development and pushing for a satisfying interface, the SemVer logic is not according to spec. Until v1.0.0, every minor release is considered possibly breaking and patch releases might contain additional features. As soon as the issue #103 is finished, there should only be tweaking left before v1.0.0 is release.
+The develop branch is under continuous breaking changes, as the interface and exported funcs/consts are still undergoing planning. Because DisGord is under development and pushing for a satisfying interface, the SemVer logic is not according to spec. Until v1.0.0, every minor release is considered possibly breaking and patch releases might contain additional features. Please see the issue and current PR's to get an idea about coming changes before v1.
 
 There might be bugs in the cache, or the cache processing might not exist yet for some REST methods. Bypass the cache for REST methods by supplying the flag argument `disgord.IgnoreCache`. eg. `client.GetCurrentUser(disgord.IgnoreCache)`.
 

--- a/flag_string.go
+++ b/flag_string.go
@@ -4,6 +4,21 @@ package disgord
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[IgnoreCache-1]
+	_ = x[IgnoreEmptyParams-2]
+	_ = x[SortByID-4]
+	_ = x[SortByName-8]
+	_ = x[SortByHoist-16]
+	_ = x[SortByGuildID-32]
+	_ = x[SortByChannelID-64]
+	_ = x[OrderAscending-128]
+	_ = x[OrderDescending-256]
+}
+
 const (
 	_Flag_name_0 = "IgnoreCacheIgnoreEmptyParams"
 	_Flag_name_1 = "SortByID"

--- a/utils.go
+++ b/utils.go
@@ -5,11 +5,6 @@ import (
 	"strings"
 )
 
-// GetShardForGuildID converts a GuildID into a ShardID for correct retrieval of guild information
-func GetShardForGuildID(guildID Snowflake, shardCount uint) (shardID uint) {
-	return uint(guildID>>22) % shardCount
-}
-
 //////////////////////////////////////////////////////
 //
 // Validators

--- a/voiceconnection.go
+++ b/voiceconnection.go
@@ -286,7 +286,7 @@ func (v *voiceImpl) speakingImpl(b bool) error {
 	return v.ws.Emit(cmd.VoiceSpeaking, &voiceSpeakingData{
 		Speaking: b,
 		SSRC:     v.ssrc,
-	})
+	}, v.guildID)
 }
 
 func (v *voiceImpl) SendOpusFrame(data []byte) {

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -305,8 +305,7 @@ func (c *client) disconnect() (err error) {
 func (c *client) Disconnect() (err error) {
 	c.Lock()
 	c.requestedDisconnect = true
-	c.
-		c.Unlock()
+	c.Unlock()
 	return c.disconnect()
 }
 

--- a/websocket/eventclient.go
+++ b/websocket/eventclient.go
@@ -370,7 +370,7 @@ func (c *EvtClient) sendHeartbeat(i interface{}) error {
 	snr := c.sequenceNumber
 	c.RUnlock()
 
-	return c.emit(true, event.Heartbeat, snr)
+	return c.emit(true, event.Heartbeat, snr, 0)
 }
 
 //////////////////////////////////////////////////////
@@ -480,7 +480,7 @@ func (c *EvtClient) sendHelloPacket() {
 		Token      string `json:"token"`
 		SessionID  string `json:"session_id"`
 		SequenceNr uint   `json:"seq"`
-	}{token, session, sequence})
+	}{token, session, sequence}, 0)
 	if err != nil {
 		c.log.Error(c.getLogPrefix(), err)
 	}
@@ -498,7 +498,7 @@ func sendIdentityPacket(invalidSession bool, c *EvtClient) (err error) {
 	*id = *c.identity
 	// copy it to avoid data race
 	c.idMu.RUnlock()
-	err = c.emit(true, event.Identify, id)
+	err = c.emit(true, event.Identify, id, 0)
 
 	if !invalidSession {
 		c.log.Debug(c.getLogPrefix(), "sendIdentityPacket is acquiring once channel")

--- a/websocket/eventclient.go
+++ b/websocket/eventclient.go
@@ -109,6 +109,8 @@ type EvtConfig struct {
 
 	connectQueue func(shardID uint, cb func() error) error
 
+	discordErrListener discordErrListener
+
 	Presence interface{}
 
 	// Endpoint for establishing socket connection. Either endpoints, `Gateway` or `Gateway Bot`, is used to retrieve
@@ -168,13 +170,13 @@ func (c *EvtClient) SetPresence(data interface{}) (err error) {
 	return nil
 }
 
-func (c *EvtClient) Emit(command string, data interface{}) (err error) {
+func (c *EvtClient) Emit(command string, data interface{}, guildID Snowflake) (err error) {
 	if command == cmd.UpdateStatus {
 		if err = c.SetPresence(data); err != nil {
 			return err
 		}
 	}
-	return c.client.emit(false, command, data)
+	return c.client.emit(false, command, data, guildID)
 }
 
 //////////////////////////////////////////////////////

--- a/websocket/packets.go
+++ b/websocket/packets.go
@@ -130,6 +130,10 @@ type GatewayBot struct {
 type clientPacket struct {
 	Op   uint        `json:"op"`
 	Data interface{} `json:"d"`
+
+	// allows restocking pkts on shard scaling
+	guildID Snowflake `json:"-"`
+	cmd     string    `json:"-"`
 }
 
 type helloPacket struct {

--- a/websocket/queue.go
+++ b/websocket/queue.go
@@ -79,4 +79,5 @@ func (c *clientPktQueue) Steal() (m []*clientPacket) {
 
 	m = c.messages
 	c.messages = c.messages[:0]
+	return m
 }

--- a/websocket/queue.go
+++ b/websocket/queue.go
@@ -26,6 +26,7 @@ func (c *clientPktQueue) IsEmpty() bool {
 
 	return len(c.messages) == 0
 }
+
 func (c *clientPktQueue) AddByOverwrite(msg *clientPacket) error {
 	c.Lock()
 	defer c.Unlock()
@@ -38,6 +39,7 @@ func (c *clientPktQueue) AddByOverwrite(msg *clientPacket) error {
 	}
 	return errors.New("no entry with existing operation code")
 }
+
 func (c *clientPktQueue) Add(msg *clientPacket) error {
 	if msg.Op == opcode.EventStatusUpdate {
 		if err := c.AddByOverwrite(msg); err == nil {
@@ -54,6 +56,7 @@ func (c *clientPktQueue) Add(msg *clientPacket) error {
 	c.messages = append(c.messages, msg)
 	return nil
 }
+
 func (c *clientPktQueue) Try(cb func(msg *clientPacket) error) error {
 	c.Lock()
 	defer c.Unlock()
@@ -73,6 +76,7 @@ func (c *clientPktQueue) Try(cb func(msg *clientPacket) error) error {
 	c.messages = c.messages[:len(c.messages)-1]
 	return nil
 }
+
 func (c *clientPktQueue) Steal() (m []*clientPacket) {
 	c.Lock()
 	defer c.Unlock()

--- a/websocket/queue_test.go
+++ b/websocket/queue_test.go
@@ -1,0 +1,133 @@
+package websocket
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/andersfylling/disgord/websocket/opcode"
+)
+
+func TestClientPktQueue_Add(t *testing.T) {
+	limit := 5
+	q := newClientPktQueue(limit)
+	if !q.IsEmpty() {
+		t.Error("should be empty")
+	}
+
+	if err := q.Add(&clientPacket{}); err != nil {
+		t.Error(err)
+	}
+
+	if q.IsEmpty() {
+		t.Error("should not be empty")
+	}
+
+	for i := 1; i < limit; i++ {
+		_ = q.Add(&clientPacket{})
+	}
+	if len(q.messages) != q.limit {
+		t.Fatal("number of entries in queue was less than the limit")
+	}
+
+	if err := q.Add(&clientPacket{}); err == nil {
+		t.Error("expected an error when trying to add to a full queue")
+	}
+
+	q.Steal()
+	_ = q.Add(&clientPacket{Op: opcode.EventStatusUpdate})
+	if len(q.messages) != 1 {
+		t.Fatal("number of entries in queue should be 1")
+	}
+	_ = q.Add(&clientPacket{Op: opcode.EventStatusUpdate})
+	if len(q.messages) != 1 {
+		t.Fatal("number of entries in queue should be 1")
+	}
+	_ = q.Add(&clientPacket{})
+	if len(q.messages) != 2 {
+		t.Fatal("number of entries in queue should be 2")
+	}
+}
+
+func TestClientPktQueue_AddByOverwrite(t *testing.T) {
+	q := newClientPktQueue(10)
+	if !q.IsEmpty() {
+		t.Error("should be empty")
+	}
+
+	if err := q.AddByOverwrite(&clientPacket{}); err == nil {
+		t.Error("should complain that no similar entry to be overwritten was found")
+	}
+
+	if !q.IsEmpty() {
+		t.Error("should be empty")
+	}
+
+	pkt := &clientPacket{}
+	if err := q.Add(pkt); err != nil {
+		t.Error(err)
+	}
+
+	if q.IsEmpty() {
+		t.Error("should not be empty")
+	}
+
+	if err := q.AddByOverwrite(pkt); err != nil {
+		t.Error(err)
+	}
+
+	if q.IsEmpty() {
+		t.Error("should not be empty")
+	}
+
+	if len(q.messages) != 1 {
+		t.Error("there should only be one item in the queue")
+	}
+}
+
+func TestClientPktQueue_Steal(t *testing.T) {
+	q := newClientPktQueue(10)
+	_ = q.Add(&clientPacket{})
+	if len(q.messages) != 1 {
+		t.Error("there should only be one item in the queue")
+	}
+
+	q.Steal()
+	if !q.IsEmpty() {
+		t.Error("should be empty")
+	}
+}
+
+func TestClientPktQueue_Try(t *testing.T) {
+	q := newClientPktQueue(10)
+	if err := q.Try(nil); err == nil {
+		t.Error("Try should fail when queue is empty")
+	}
+
+	_ = q.Add(&clientPacket{})
+	if err := q.Try(func(msg *clientPacket) error { return errors.New("") }); err == nil {
+		t.Error("Try should fail when cb returns an error")
+	}
+	if len(q.messages) != 1 {
+		t.Error("the number of entries in the queue should not reduce after a failed Try execution")
+	}
+
+	if err := q.Try(func(msg *clientPacket) error { return nil }); err != nil {
+		t.Error("Try should not have failed", err)
+	}
+	if !q.IsEmpty() {
+		t.Error("queue should be empty")
+	}
+
+	_ = q.Add(&clientPacket{guildID: 1})
+	_ = q.Add(&clientPacket{guildID: 2})
+	_ = q.Add(&clientPacket{guildID: 3})
+	if err := q.Try(func(msg *clientPacket) error { return nil }); err != nil {
+		t.Error("Try should not have failed", err)
+	}
+	if len(q.messages) != 2 {
+		t.Error("the number of entries in the queue should reduce after Try execution")
+	}
+	if q.messages[0].guildID != Snowflake(2) {
+		t.Error("Try should pop the first entry (FIFO)")
+	}
+}

--- a/websocket/sharding.go
+++ b/websocket/sharding.go
@@ -324,7 +324,6 @@ func (s *shardMngr) scale(code int, reason string) {
 	_ = s.Disconnect()
 
 	s.conf.URL = data.URL
-	s.conf.ShardIDs = s.conf.ShardIDs[:0]
 	for i := uint(len(s.conf.ShardIDs) - 1); i < data.Shards; i++ {
 		s.conf.ShardIDs = append(s.conf.ShardIDs, i)
 	}

--- a/websocket/sharding.go
+++ b/websocket/sharding.go
@@ -130,6 +130,7 @@ type ShardManagerConfig struct {
 	HTTPClient   *http.Client
 	Logger       logger.Logger
 	ShutdownChan chan interface{}
+	conn         Conn
 
 	// ...
 	TrackedEvents *UniqueStringSlice
@@ -184,6 +185,7 @@ func (s *shardMngr) initializeShards() error {
 		// other
 		SystemShutdown:     s.conf.ShutdownChan,
 		discordErrListener: s.scale,
+		conn:               s.conf.conn,
 	}
 
 	for _, id := range s.conf.ShardIDs {

--- a/websocket/sharding.go
+++ b/websocket/sharding.go
@@ -256,7 +256,7 @@ func (s *shardMngr) Emit(cmd string, data interface{}, id Snowflake) (err error)
 			err = shard.Emit(cmd, data, id)
 		}
 	} else {
-		shardID := GetShardForGuildID(id, uint(len(s.shards)))
+		shardID := GetShardForGuildID(id, s.conf.TotalNumberOfShards)
 		if shard, exists := s.shards[shardID]; exists {
 			err = shard.Emit(cmd, data, id)
 		} else {

--- a/websocket/sharding_test.go
+++ b/websocket/sharding_test.go
@@ -1,0 +1,106 @@
+package websocket
+
+import (
+	"testing"
+)
+
+type GatewayBotGetterMock struct {
+	get func() (gateway *GatewayBot, err error)
+}
+
+func (g GatewayBotGetterMock) GetGatewayBot() (gateway *GatewayBot, err error) {
+	return g.get()
+}
+
+var _ GatewayBotGetter = (*GatewayBotGetterMock)(nil)
+
+func TestConfigureShardConfig(t *testing.T) {
+	nrOfShards := uint(4)
+	u := "localhost:6060"
+	mock := &GatewayBotGetterMock{
+		get: func() (gateway *GatewayBot, err error) {
+			return &GatewayBot{
+				Shards:  nrOfShards,
+				Gateway: Gateway{u},
+			}, nil
+		},
+	}
+
+	conf := ShardConfig{}
+	if err := ConfigureShardConfig(mock, &conf); err != nil {
+		t.Error(err)
+	}
+	if conf.URL != u {
+		t.Error("url was not set")
+	}
+	if len(conf.ShardIDs) != int(conf.TotalNumberOfShards) && conf.TotalNumberOfShards != nrOfShards {
+		t.Error("incorrectly set number of shards")
+	}
+	if conf.DisableAutoScaling {
+		t.Error("DisableAutoScaling should not be true")
+	}
+
+	conf = ShardConfig{
+		ShardIDs: []uint{34, 7, 2},
+	}
+	if err := ConfigureShardConfig(mock, &conf); err != nil {
+		t.Error(err)
+	}
+	if !conf.DisableAutoScaling {
+		t.Error("DisableAutoScaling should be true")
+	}
+
+	conf = ShardConfig{
+		ShardIDs:            []uint{34, 7, 2},
+		TotalNumberOfShards: 34,
+	}
+	if err := ConfigureShardConfig(mock, &conf); err != nil {
+		t.Error(err)
+	}
+	if !conf.DisableAutoScaling {
+		t.Error("DisableAutoScaling should be true")
+	}
+}
+
+//
+//func TestShardAutoScalingFailsafe(t *testing.T) {
+//	// when discord disconnects one or more shards with the websocket
+//	// error 4011: require shard scaling
+//
+//	eChan := make(chan *Event)
+//	shutdown := make(chan interface{})
+//	done := make(chan interface{})
+//	deadline := 1 * time.Second
+//	nrOfShards := uint(4)
+//	conn := &testWS{
+//		closing:      make(chan interface{}),
+//		opening:      make(chan interface{}),
+//		writing:      make(chan interface{}),
+//		reading:      make(chan []byte),
+//		disconnected: true,
+//	}
+//
+//	mngr := NewShardMngr(ShardManagerConfig{
+//		ShardConfig: ShardConfig{
+//			ShardIDs: []uint{0, 1},
+//		},
+//		DisgordInfo:   "",
+//		BotToken:      "",
+//		Proxy:         nil,
+//		HTTPClient:    nil,
+//		Logger:        logger.DefaultLogger(true),
+//		ShutdownChan:  shutdown,
+//		conn:          conn,
+//		TrackedEvents: nil,
+//		EventChan:     eChan,
+//		RESTClient: &GatewayBotGetterMock{
+//			get: func() (gateway *GatewayBot, err error) {
+//				return &GatewayBot{
+//					Shards: nrOfShards,
+//				}, nil
+//			},
+//		},
+//		DefaultBotPresence: nil,
+//		ProjectName:        "",
+//	})
+//}

--- a/websocket/sharding_test.go
+++ b/websocket/sharding_test.go
@@ -82,7 +82,7 @@ func TestConfigureShardConfig(t *testing.T) {
 //
 //	mngr := NewShardMngr(ShardManagerConfig{
 //		ShardConfig: ShardConfig{
-//			ShardIDs: []uint{0, 1},
+//			shardIDs: []uint{0, 1},
 //		},
 //		DisgordInfo:   "",
 //		BotToken:      "",

--- a/websocket/voiceclient.go
+++ b/websocket/voiceclient.go
@@ -134,7 +134,7 @@ func (c *VoiceClient) onReady(v interface{}) (err error) {
 
 func (c *VoiceClient) onHeartbeatRequest(v interface{}) error {
 	// https://discordapp.com/developers/docs/topics/gateway#heartbeating
-	return c.emit(true, cmd.VoiceHeartbeat, nil)
+	return c.emit(true, cmd.VoiceHeartbeat, nil, 0)
 }
 
 func (c *VoiceClient) onHeartbeatAck(v interface{}) error {
@@ -188,7 +188,7 @@ func (c *VoiceClient) onVoiceSessionDescription(v interface{}) (err error) {
 //////////////////////////////////////////////////////
 
 func (c *VoiceClient) sendHeartbeat(i interface{}) error {
-	return c.emit(true, cmd.VoiceHeartbeat, nil)
+	return c.emit(true, cmd.VoiceHeartbeat, nil, 0)
 }
 
 //////////////////////////////////////////////////////
@@ -274,7 +274,7 @@ func (c *VoiceClient) sendVoiceHelloPacket() {
 		GuildID   Snowflake `json:"server_id"`
 		SessionID string    `json:"session_id"`
 		Token     string    `json:"token"`
-	}{c.conf.GuildID, c.conf.SessionID, c.conf.Token})
+	}{c.conf.GuildID, c.conf.SessionID, c.conf.Token}, 0)
 }
 
 func sendVoiceIdentityPacket(m *VoiceClient) (err error) {
@@ -284,7 +284,7 @@ func sendVoiceIdentityPacket(m *VoiceClient) (err error) {
 		UserID:    m.conf.UserID,
 		SessionID: m.conf.SessionID,
 		Token:     m.conf.Token,
-	})
+	}, 0)
 
 	m.haveIdentifiedOnce = true
 	return
@@ -297,7 +297,7 @@ func (c *VoiceClient) SendUDPInfo(data *VoiceSelectProtocolParams) (ret *VoiceSe
 	err = c.emit(true, cmd.VoiceSelectProtocol, &voiceSelectProtocol{
 		Protocol: "udp",
 		Data:     data,
-	})
+	}, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -19,6 +19,7 @@ type Conn interface {
 }
 
 type CloseErr struct {
+	code int
 	info string
 }
 

--- a/websocket/websocket_gorilla.go
+++ b/websocket/websocket_gorilla.go
@@ -78,8 +78,9 @@ func (g *gorilla) Read(ctx context.Context) (packet []byte, err error) {
 	var messageType int
 	messageType, packet, err = g.c.ReadMessage()
 	if err != nil {
-		if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+		if e, ok := err.(*websocket.CloseError); ok {
 			err = &CloseErr{
+				code: e.Code,
 				info: err.Error(),
 			}
 		}

--- a/websocket/websocket_nhooyr.go
+++ b/websocket/websocket_nhooyr.go
@@ -66,6 +66,7 @@ func (g *nhooyr) Read(ctx context.Context) (packet []byte, err error) {
 		var closeErr *websocket.CloseError
 		if errors.As(err, &closeErr) {
 			err = &CloseErr{
+				code: int(closeErr.Code),
 				info: closeErr.Error(),
 			}
 		}


### PR DESCRIPTION
# Description

Triggers shard scaling on 4011 discord errors. Also re-distributes queued client pkt amoung the new shards with respect to their shard id (guildID>>22%nrOfShards).

Fixes #184 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (removes disgord.GetShardForGuildID(...))

# Checklist:

- [x] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
