### PR TITLE
auto release on milestone close

### DIFF
--- a/.github/milestone-release.sh
+++ b/.github/milestone-release.sh
@@ -17,8 +17,8 @@ rm gith
 rm "closed_milestones.txt"
 
 # setup git env
-git config user.email "anders@nordic.email"
-git config user.name "Anders Fylling (bot)"
+git config user.email "${GITHUB_EMAIL}"
+git config user.name "https://github.com/andersfylling"
 git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
 git checkout develop
 
@@ -35,4 +35,4 @@ github_changelog_generator --release-branch develop -u andersfylling -p disgord
 git add .
 git commit -m "gen changelog & set version to ${VERSION}"
 git tag "${VERSION}" -m "DisGord ${VERSION}"
-(git diff --quiet && git diff --staged --quiet) || (git commit -m "${COMMIT_MSG}"; git push origin develop --tags)
+git push origin develop --tags

--- a/.github/milestone-release.sh
+++ b/.github/milestone-release.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# github REST commands
+wget https://raw.githubusercontent.com/whiteinge/ok.sh/master/ok.sh -O gith
+chmod +x gith
+
+# get last closed milestone (yes this is a race cond)
+./gith list_milestones andersfylling/disgord state=closed sort=closed_at direction=desc > closed_milestones.txt
+VERSION="$(awk 'NR==1 {print $3}' "closed_milestones.txt")"
+if [[ ! ${VERSION:0:1} == "v" ]] ; then
+  >&2 echo "ERROR: $(cat closed_milestones.txt)";
+  exit 1
+fi
+
+# cleanup
+rm gith
+rm "closed_milestones.txt"
+
+# setup git env
+git config user.email "anders@nordic.email"
+git config user.name "Anders Fylling (bot)"
+git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+git checkout develop
+
+# update version const
+VERSION_FILE="constant/version.go"
+echo "package constant" > "${VERSION_FILE}"
+echo "const Version = \"${VERSION}\"" >> "${VERSION_FILE}"
+go fmt ./...
+
+# generate CHANGELOG.md
+github_changelog_generator --release-branch develop -u andersfylling -p disgord
+
+# commit, tag and push
+git add .
+git commit -m "gen changelog & set version to ${VERSION}"
+git tag "${VERSION}" -m "DisGord ${VERSION}"
+(git diff --quiet && git diff --staged --quiet) || (git commit -m "${COMMIT_MSG}"; git push origin develop --tags)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+on:
+  milestone:
+    types: [closed]
+name: GoReleaser
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    #needs: [ test ]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@develop
+      - name: Update disgord version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+        run: sh .github/milestone-release.sh
+      - name: goreleaser
+        uses: docker://goreleaser/goreleaser
+        env:
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        with:
+          args: release
+        if: success()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Update disgord version
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          GITHUB_EMAIL: ${{ secrets.GITHUB_EMAIL }}
         run: sh .github/milestone-release.sh
       - name: goreleaser
         uses: docker://goreleaser/goreleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,9 +33,6 @@ dockers:
       - "--label=com.github.actions.description=DisGord is a Go module for interacting with Discord"
       - "--label=repository=http://github.com/andersfylling/disgord"
       - "--label=maintainer=Anders Fylling <anders@nordic.email>"
-
-    extra_files:
-      - scripts/entrypoint.sh
 archives:
   - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     format_overrides:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,43 @@
+project_name: DisGord
+env:
+  - GO111MODULE=on
+before:
+  hooks:
+    - go fmt ./...
+    - go mod tidy
+changelog:
+  sort: asc
+  filters:
+    # commit messages matching the regexp listed here will be removed from
+    # the changelog
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - typo
+      - cleanup
+      - whops
+      - fmt
+      - generate
+dockers:
+  - image_templates:
+      - 'andersfylling/disgord:{{ .Tag }}'
+      - 'andersfylling/disgord:latest'
+    dockerfile: Dockerfile
+    binaries:
+      - goreleaser
+    build_flag_templates:
+      - "--label=org.label-schema.schema-version=1.0"
+      - "--label=org.label-schema.version={{.Version}}"
+      - "--label=org.label-schema.name={{.ProjectName}}"
+      - "--label=com.github.actions.name={{.ProjectName}}"
+      - "--label=com.github.actions.description=DisGord is a Go module for interacting with Discord"
+      - "--label=repository=http://github.com/andersfylling/disgord"
+      - "--label=maintainer=Anders Fylling <anders@nordic.email>"
+
+    extra_files:
+      - scripts/entrypoint.sh
+archives:
+  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    format_overrides:
+      - goos: windows
+        format: zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM golang:1.13
 MAINTAINER https://github.com/andersfylling
 WORKDIR /build
-COPY . /build
-RUN export GO111MODULE=on
+COPY cmd/docker /build
+RUN go mod download
 RUN go test ./...
 RUN rm -rf /build
-

--- a/cmd/docker/docker-compose.yaml
+++ b/cmd/docker/docker-compose.yaml
@@ -1,5 +1,0 @@
-version: '3'
-services:
-  disgord:
-    build: .
-    image: andersfylling/disgord:v0.12.0-rc3

--- a/cmd/docker/update.sh
+++ b/cmd/docker/update.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-docker-compose build
-docker push andersfylling/disgord


### PR DESCRIPTION
This will automatically generate CHANGELOG.md, update disgord version const, fmt code, commit, tag and create a github release when a milestone closes.

The title of the milestone is used as the version. 

WARNING! This change means once a milestone is closed, it can not be re-opened. EVERY close cause a release, and this release is assumed to be the newest/highest version. This is bad, but I don't have a proper fix for it yet.

Fixes #191 