### PR TITLE
Introduce better global LoadAllMembers function

### DIFF
--- a/guild.go
+++ b/guild.go
@@ -406,15 +406,9 @@ func (g *Guild) hasMember(id Snowflake) bool {
 	return false
 }
 
-func (g *Guild) addMembers(members ...*Member) error {
-	if members == nil {
-		return errors.New("members was nil")
-	}
-
+func (g *Guild) addMembers(members ...*Member) {
 	// TODO: implement sorting for faster searching later
 	g.Members = append(g.Members, members...)
-
-	return nil
 }
 
 // AddMembers adds multiple members to the Guild object. Note that this method does not interact with Discord.
@@ -446,7 +440,7 @@ func (g *Guild) AddMember(member *Member) error {
 
 	// TODO: Check for userID.IsZero()
 	if !g.hasMember(member.userID) {
-		return g.addMembers(member)
+		g.addMembers(member)
 	}
 
 	return nil

--- a/guild.go
+++ b/guild.go
@@ -1064,7 +1064,9 @@ var _ fmt.Stringer = (*Member)(nil)
 var _ internalUpdater = (*Member)(nil)
 
 func (m *Member) updateInternals() {
-	m.userID = m.User.ID
+	if m.User != nil {
+		m.userID = m.User.ID
+	}
 }
 
 func (m *Member) String() string {

--- a/guild.go
+++ b/guild.go
@@ -1060,6 +1060,12 @@ type Member struct {
 }
 
 var _ Reseter = (*Member)(nil)
+var _ fmt.Stringer = (*Member)(nil)
+var _ internalUpdater = (*Member)(nil)
+
+func (m *Member) updateInternals() {
+	m.userID = m.User.ID
+}
 
 func (m *Member) String() string {
 	usrname := m.Nick

--- a/guild.go
+++ b/guild.go
@@ -1684,6 +1684,8 @@ func (c *Client) LoadMembers(ctx context.Context, payload *RequestGuildMembersPa
 	evtCtx, isDone := context.WithCancel(context.Background())
 	members = make([]*Member, 0, estimatedMemberCount)
 
+	defer isDone()
+
 	// Small helper utility to check if event is related to this payload
 	forThisPayload := func(e *GuildMembersChunk) bool {
 		for _, guildID := range payload.GuildIDs {

--- a/guild.go
+++ b/guild.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
-	"time"
 
 	"github.com/andersfylling/disgord/endpoint"
 	"github.com/andersfylling/disgord/httd"
@@ -452,19 +451,17 @@ func (g *Guild) AddMember(member *Member) error {
 	return nil
 }
 
-// LoadAllMembers fetches all the members for this guild from the Discord Gateway.
-// This function will block until all members are loaded, or when the context is canceled
+// LoadAllMembers uses the Gateway to synchronously load all members of a Guild.
+// Will emit an Request Guild Members event to Gateway. Gateway will respond with Guild Member Chunk events
+// whose can hold up to 1000 members. The Gateway will keep sending this event until all members have been received.
+// Be cautious, this can take long on big guilds and it's recommended using context.WithTimeout on the context.
 func (g *Guild) LoadAllMembers(ctx context.Context, s Session) (err error) {
-	if constant.LockedMethods {
-		g.Lock()
-		defer g.Unlock()
-	}
-
 	// Check if guild is already loaded
-	// TODO: Check whether this is actually the best way to check
-	if uint(len(g.Members)) == g.MemberCount {
-		return nil
-	}
+	// TODO: Check in a margin of g.MemberCount + %2 + 5
+	//mLen := uint(len(g.Members))
+	//if mLen >= g.MemberCount - 5 && mLen <= g.MemberCount + 5 {
+	//	return nil
+	//}
 
 	err = s.Emit(CommandRequestGuildMembers, RequestGuildMembersCommand{GuildID: g.ID})
 	if err != nil {
@@ -474,6 +471,7 @@ func (g *Guild) LoadAllMembers(ctx context.Context, s Session) (err error) {
 	chunkEvtChan := make(chan *GuildMembersChunk, 1+g.MemberCount/1000)
 	ctrl := &Ctrl{Channel: chunkEvtChan}
 	evtCtx, isDone := context.WithCancel(context.Background())
+	members := make([]*Member, 0, g.MemberCount)
 
 	s.On(EvtGuildMembersChunk, chunkEvtChan, ctrl)
 	for {
@@ -483,19 +481,16 @@ func (g *Guild) LoadAllMembers(ctx context.Context, s Session) (err error) {
 				continue
 			}
 
+			members = append(members, e.Members...)
+
 			// GW will return chunks of 1k members, when less, last members are received
 			if len(e.Members) < 1000 {
 				isDone()
 			}
 			continue
 
-		// TODO: Make dynamic timeout?
-		//		 Allow people to set a timeout on the ctx themselves maybe>
-		case <-time.After(10 * time.Second):
-			err = errors.New("loading timed out")
 		case <-ctx.Done():
-			// TODO: errors.Wrap(ctx.Err())
-			err = errors.New("loading was canceled")
+			err = errors.New("loading was canceled, " + ctx.Err().Error())
 		case <-evtCtx.Done():
 		}
 		break
@@ -503,9 +498,9 @@ func (g *Guild) LoadAllMembers(ctx context.Context, s Session) (err error) {
 
 	ctrl.CloseChannel()
 
-	members, err := s.GetMembers(g.ID, nil)
-	if err != nil {
-		return err
+	if constant.LockedMethods {
+		g.Lock()
+		defer g.Unlock()
 	}
 	g.Members = members
 

--- a/iface_internalupdaters_gen.go
+++ b/iface_internalupdaters_gen.go
@@ -106,6 +106,17 @@ func executeInternalUpdater(x interface{}) {
 		for i := range slice {
 			update(slice[i])
 		}
+	case *Member:
+		update(t)
+	case []*Member:
+		for i := range t {
+			update(t[i])
+		}
+	case *[]*Member:
+		slice := *t
+		for i := range slice {
+			update(slice[i])
+		}
 	case *Message:
 		update(t)
 	case []*Message:

--- a/session.go
+++ b/session.go
@@ -251,11 +251,11 @@ type RESTGuild interface {
 	// GetMembers uses the GetGuildMembers endpoint iteratively until your query params are met.
 	GetMembers(guildID Snowflake, params *GetMembersParams, flags ...Flag) ([]*Member, error)
 
-	// LoadAllMembers uses the Gateway to synchronously load all members of a Guild.
+	// LoadMembers uses the Gateway to synchronously load members of guilds.
 	// Will emit an Request Guild Members event to Gateway. Gateway will respond with Guild Member Chunk events
 	// whose can hold up to 1000 members. The Gateway will keep sending this event until all members have been received.
 	// Be cautious, this can take long on big guilds and it's recommended using context.WithTimeout on the context.
-	LoadMembers(ctx context.Context, guildID Snowflake, flags ...Flag) ([]*Member, error)
+	LoadMembers(ctx context.Context, payload *RequestGuildMembersPayload) ([]*Member, error)
 
 	// AddGuildMember Adds a user to the guild, provided you have a valid oauth2 access token for the user with
 	// the guilds.join scope. Returns a 201 Created with the guild member as the body, or 204 No Content if the user is

--- a/session.go
+++ b/session.go
@@ -1,6 +1,7 @@
 package disgord
 
 import (
+	"context"
 	"time"
 
 	"github.com/andersfylling/disgord/logger"
@@ -249,6 +250,12 @@ type RESTGuild interface {
 
 	// GetMembers uses the GetGuildMembers endpoint iteratively until your query params are met.
 	GetMembers(guildID Snowflake, params *GetMembersParams, flags ...Flag) ([]*Member, error)
+
+	// LoadAllMembers uses the Gateway to synchronously load all members of a Guild.
+	// Will emit an Request Guild Members event to Gateway. Gateway will respond with Guild Member Chunk events
+	// whose can hold up to 1000 members. The Gateway will keep sending this event until all members have been received.
+	// Be cautious, this can take long on big guilds and it's recommended using context.WithTimeout on the context.
+	LoadMembers(ctx context.Context, guildID Snowflake, flags ...Flag) ([]*Member, error)
 
 	// AddGuildMember Adds a user to the guild, provided you have a valid oauth2 access token for the user with
 	// the guilds.join scope. Returns a 201 Created with the guild member as the body, or 204 No Content if the user is


### PR DESCRIPTION
# Description

DisGord has a Guild.LoadAllMembers function, this function is supposed to fetch all members of a guild and cache them. There are currently two issues with this function. The first issue is that this function will only work for guilds up to 1000 members. Furthermore, the function does not check for duplicated members which causes an incorrect slice of members.

This PR will move the Guild.LoadAllMembers function to Client.LoadMembers. The function uses Discord's Gateway to request members using the [Request Guild Members](https://discordapp.com/developers/docs/topics/gateway#request-guild-members) command. This command will trigger multiple [Guild Member Chunk](https://discordapp.com/developers/docs/topics/gateway#guild-members-chunk) events. Each chunk can hold up to 1000 members.

The function can now also be used to fetch members from multiple guilds and fetch by query as the function supports a `*RequestGuildMembers` as second parameter.

When I started working on this PR the idea was to only fix #190. While adding a function to check if a member already existed in the members slice I found out the Member struct did not implement `internalUpdater` yet, causing the Member.userID to be 0 (#193) this has been fixed in this PR as well.

Fixes #190 
Fixes #193 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
