### PR TITLE
fixes client.Ready for distributed bots

### DIFF
--- a/websocket/sharding.go
+++ b/websocket/sharding.go
@@ -310,7 +310,9 @@ func (s *shardMngr) Disconnect() error {
 func (s *shardMngr) NrOfShards() uint {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.conf.TotalNumberOfShards
+
+	// ShardIDs will always reflect the number of shards for this instance
+	return uint(len(s.conf.ShardIDs))
 }
 
 func (s *shardMngr) shardIDs() (shardIDs []uint) {


### PR DESCRIPTION
# Description

client.Ready would not work on distributed bots as it would wait for all shards to receive a ready event. However, it cannot access all shards and therefore fails. This change makes sure it only checks the local shards for a ready event.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)