### PR TITLE
fixes issue with identify for distributed bots doing sharding

### DIFF
--- a/event/events.go
+++ b/event/events.go
@@ -1,9 +1,6 @@
 // Package event is a universal discord package that holds all the event types one can receive (currently only bot events).
 package event
 
-// PresencesReplace Holds and array of presence update objects
-const PresencesReplace = "PRESENCES_REPLACE"
-
 // Ready The ready event is dispatched when a client has completed the initial handshake with the gateway (for new sessions).
 //// The ready event can be the largest and most complex event the gateway will send, as it contains all the state
 //// required for a client to begin interacting with the rest of the platform.

--- a/events.go
+++ b/events.go
@@ -157,15 +157,6 @@ type evtResource interface {
 
 // ---------------------------
 
-// PresencesReplace holds the event content
-type PresencesReplace struct {
-	Presnces []*PresenceUpdate `json:"presences_replace"` // TODO: verify json tag
-	Ctx      context.Context   `json:"-"`
-	ShardID  uint              `json:"-"`
-}
-
-// ---------------------------
-
 // Ready contains the initial state information
 type Ready struct {
 	APIVersion int                 `json:"v"`

--- a/events_gen.go
+++ b/events_gen.go
@@ -312,15 +312,6 @@ func (h *PresenceUpdate) setShardID(id uint)                  { h.ShardID = id }
 
 // ---------------------------
 
-// EvtPresencesReplace Holds and array of presence update objects
-//
-const EvtPresencesReplace = event.PresencesReplace
-
-func (h *PresencesReplace) registerContext(ctx context.Context) { h.Ctx = ctx }
-func (h *PresencesReplace) setShardID(id uint)                  { h.ShardID = id }
-
-// ---------------------------
-
 // EvtReady The ready event is dispatched when a client has completed the initial handshake with the gateway (for new sessions).
 // // The ready event can be the largest and most complex event the gateway will send, as it contains all the state
 // // required for a client to begin interacting with the rest of the platform.

--- a/reactor_gen.go
+++ b/reactor_gen.go
@@ -64,8 +64,6 @@ func defineResource(evt string) (resource evtResource) {
 		resource = &MessageUpdate{}
 	case EvtPresenceUpdate:
 		resource = &PresenceUpdate{}
-	case EvtPresencesReplace:
-		resource = &PresencesReplace{}
 	case EvtReady:
 		resource = &Ready{}
 	case EvtResumed:
@@ -197,10 +195,6 @@ func isHandler(h Handler) (ok bool) {
 		ok = true
 	case chan *PresenceUpdate:
 		ok = true
-	case PresencesReplaceHandler:
-		ok = true
-	case chan *PresencesReplace:
-		ok = true
 	case ReadyHandler:
 		ok = true
 	case chan *Ready:
@@ -288,8 +282,6 @@ func closeChannel(channel interface{}) {
 	case chan *MessageUpdate:
 		close(t)
 	case chan *PresenceUpdate:
-		close(t)
-	case chan *PresencesReplace:
 		close(t)
 	case chan *Ready:
 		close(t)
@@ -491,12 +483,6 @@ func (d *dispatcher) trigger(h Handler, evt resource) {
 		t <- evt.(*PresenceUpdate)
 	case chan<- *PresenceUpdate:
 		t <- evt.(*PresenceUpdate)
-	case PresencesReplaceHandler:
-		t(d.session, evt.(*PresencesReplace))
-	case chan *PresencesReplace:
-		t <- evt.(*PresencesReplace)
-	case chan<- *PresencesReplace:
-		t <- evt.(*PresencesReplace)
 	case ReadyHandler:
 		t(d.session, evt.(*Ready))
 	case chan *Ready:
@@ -625,9 +611,6 @@ type MessageUpdateHandler = func(s Session, h *MessageUpdate)
 
 // PresenceUpdateHandler is triggered in PresenceUpdate events
 type PresenceUpdateHandler = func(s Session, h *PresenceUpdate)
-
-// PresencesReplaceHandler is triggered in PresencesReplace events
-type PresencesReplaceHandler = func(s Session, h *PresencesReplace)
 
 // ReadyHandler is triggered in Ready events
 type ReadyHandler = func(s Session, h *Ready)

--- a/sort_gen.go
+++ b/sort_gen.go
@@ -187,8 +187,6 @@ func derefSliceP(v interface{}) (s interface{}) {
 		s = *t
 	case *[]*PresenceUpdate:
 		s = *t
-	case *[]*PresencesReplace:
-		s = *t
 	case *[]*Ready:
 		s = *t
 	case *[]*Resumed:


### PR DESCRIPTION
# Description

It was discovered by github.com/victionn that distributed bots that held their own shards, had connection issues. It was later discovered that the identify payload incorrectly set the shard count. This PR resolves this.

An additional change is that PRESENCE_REPLACE is now always ignored and have been removed from DisGord as this is bs event.

The client.Ready has also been tested to work with the new changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
