### PR TITLE
add GuildsReady method (fixes #198)

### DIFF
--- a/client.go
+++ b/client.go
@@ -530,6 +530,7 @@ func (c *Client) Ready(cb func()) {
 	}, ctrl)
 }
 
+// GuildsReady is triggered once all unavailable guilds given in the READY event has loaded from their respective GUILD_CREATE events.
 func (c *Client) GuildsReady(cb func()) {
 	ctrl := &guildsRdyCtrl{
 		status: make(map[Snowflake]bool),


### PR DESCRIPTION
# Description

In addition to the Client.Ready, this PR introduces Client.GuildsReady(...) which is triggered once all expected guild create events have been received.

fixes #198

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] I ran `go generate`
- [ ] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
