### PR TITLE
panic when registerring a incorrect handler signature (fixes #20…

### DIFF
--- a/generate/discorddocs/go.sum
+++ b/generate/discorddocs/go.sum
@@ -74,12 +74,14 @@ github.com/twitchyliquid64/golang-asm v0.0.0-20190126203739-365674df15fc/go.mod 
 go.coder.com/go-tools v0.0.0-20190317003359-0c6a35b74a16/go.mod h1:iKV5yK9t+J5nG9O3uF6KYdPEz3dyfMyB15MN1rbQ8Qw=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
+go.uber.org/multierr v1.2.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20180426230345-b49d69b5da94/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
+golang.org/x/crypto v0.0.0-20190927123631-a832865fa7ad/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -94,6 +96,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190926025831-c00fd9afed17/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -110,6 +113,7 @@ golang.org/x/sys v0.0.0-20190830142957-1e83adbbebd0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190919044723-0c1ff786ef13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190927073244-c990c680b611/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -139,3 +143,4 @@ nhooyr.io/websocket v1.4.0/go.mod h1:ovvaecT36UqrInacsgoPYh0pdj0n8O7Tk9C/DeVPAAc
 nhooyr.io/websocket v1.5.0/go.mod h1:KggLY11eWdwM4pgRmntd+MQ34OM6so9x23BhTRcyJsc=
 nhooyr.io/websocket v1.5.1/go.mod h1:r5uDcVKmfhkWhkkhojbsexdcoLnMNz2SogiKiwtXZc4=
 nhooyr.io/websocket v1.6.2/go.mod h1:xhtWZS7nD5ns/9ziyL7ERGHz7MBEOLLrg3g+YLVyYI8=
+nhooyr.io/websocket v1.6.4/go.mod h1:xhtWZS7nD5ns/9ziyL7ERGHz7MBEOLLrg3g+YLVyYI8=

--- a/test/integration_client_test.go
+++ b/test/integration_client_test.go
@@ -1,0 +1,58 @@
+package test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/andersfylling/disgord"
+)
+
+func TestOn(t *testing.T) {
+	c := disgord.New(&disgord.Config{
+		BotToken:     "sdkjfhdksfhskdjfhdkfjsd",
+		DisableCache: true,
+	})
+
+	t.Run("normal Session", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("should not have triggered a panic")
+			}
+		}()
+
+		c.On(disgord.EvtChannelCreate, func(s disgord.Session, e *disgord.ChannelCreate) {})
+	})
+
+	t.Run("normal Session with ctrl", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("should not have triggered a panic")
+			}
+		}()
+
+		c.On(disgord.EvtChannelCreate, func(s disgord.Session, e *disgord.ChannelCreate) {}, &disgord.Ctrl{Runs: 1})
+	})
+
+	t.Run("normal Session with multiple ctrl's", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("multiple controllers should trigger a panic")
+			}
+		}()
+
+		c.On(disgord.EvtChannelCreate,
+			func(s disgord.Session, e *disgord.ChannelCreate) {},
+			&disgord.Ctrl{Runs: 1},
+			&disgord.Ctrl{Until: time.Now().Add(1 * time.Minute)})
+	})
+
+	t.Run("Session pointer", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("Did not panic on incorrect handler signature")
+			}
+		}()
+
+		c.On(disgord.EvtChannelCreate, func(s *disgord.Session, e *disgord.ChannelCreate) {})
+	})
+}

--- a/utils.go
+++ b/utils.go
@@ -30,14 +30,23 @@ func ValidateHandlerInputs(inputs ...interface{}) (err error) {
 		return errors.New("missing handler(s)")
 	}
 
+	for ; i < len(inputs); i++ {
+		if _, ok = inputs[i].(HandlerCtrl); ok {
+			i--
+			break
+		}
+
+		if !isHandler(inputs[i]) {
+			return errors.New("invalid handler signature. General tip: no handlers can use the param type `*disgord.Session`, try `disgord.Session` instead")
+		}
+	}
+
 	// check for extra controllers
 	for j := len(inputs) - 2; j >= i; j-- {
 		if _, ok = inputs[j].(HandlerCtrl); ok {
 			return errors.New("a handlerCtrl's can only be at the end of the definition. Expected a handler")
 		}
 	}
-
-	// TODO: test for all handler types?
 
 	return nil
 }


### PR DESCRIPTION
# Description

passing a incorrect handler type in Client.On now triggers a panic. Also added a general tip to not use *disgord.Session, but disgord.Session instead.

fixes #208

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] I ran `go generate`
- [ ] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
