### PR TITLE
Fix voice options not being used (self-mute & deafen)

### DIFF
--- a/voiceconnection.go
+++ b/voiceconnection.go
@@ -107,8 +107,8 @@ func (r *voiceRepository) VoiceConnectOptions(guildID, channelID Snowflake, self
 	_, err = r.c.Emit(UpdateVoiceState, &UpdateVoiceStatePayload{
 		GuildID:   guildID,
 		ChannelID: channelID,
-		SelfDeaf:  false,
-		SelfMute:  false,
+		SelfDeaf:  selfDeaf,
+		SelfMute:  selfMute,
 	})
 	if err != nil {
 		return


### PR DESCRIPTION
# Description

Fixes the recently added option which allows a bot to connect muted and/or deafened.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
