### PR TITLE
Fixes panic not exiting the program

### DIFF
--- a/client.go
+++ b/client.go
@@ -451,6 +451,12 @@ func (c *Client) Suspend() (err error) {
 
 // DisconnectOnInterrupt wait until a termination signal is detected
 func (c *Client) DisconnectOnInterrupt() (err error) {
+	// catches panic when being called as a deferred function
+	if r := recover(); r != nil {
+		panic("unable to connect due to above error")
+		return
+	}
+
 	<-CreateTermSigListener()
 	return c.Disconnect()
 }
@@ -458,6 +464,12 @@ func (c *Client) DisconnectOnInterrupt() (err error) {
 // StayConnectedUntilInterrupted is a simple wrapper for connect, and disconnect that listens for system interrupts.
 // When a error happens you can terminate the application without worries.
 func (c *Client) StayConnectedUntilInterrupted(ctx context.Context) (err error) {
+	// catches panic when being called as a deferred function
+	if r := recover(); r != nil {
+		panic("unable to connect due to above error")
+		return
+	}
+
 	if err = c.Connect(ctx); err != nil {
 		c.log.Error(err)
 		return err


### PR DESCRIPTION
# Description

The program wouldn't panic when client.On() threw a panic and DisconnectOnInterrupt() or StayConnectedUntilInterrupted() were deferred.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
