### PR TITLE
Fix validate handler

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -43,7 +43,7 @@ func ValidateHandlerInputs(inputs ...interface{}) (err error) {
 
 	for j := i; j < len(inputs); j++ {
 		if _, ok = inputs[j].(HandlerCtrl); ok {
-			// first element after middlewares and last input
+			// first element after middlewares and last in inputs
 			if j == i && len(inputs)-1 == j {
 				return errors.New("missing handler(s)")
 			}
@@ -52,6 +52,9 @@ func ValidateHandlerInputs(inputs ...interface{}) (err error) {
 				return errors.New("a handlerCtrl's can only be at the end of the definition and only one")
 			}
 			break
+		}
+		if _, ok = inputs[j].(Ctrl); ok {
+			return errors.New("want disgord.HandlerCtrl not disgord.Ctrl. Try to use &disgord.Ctrl instead of disgord.Ctrl")
 		}
 
 		if !isHandler(inputs[j]) {

--- a/utils.go
+++ b/utils.go
@@ -41,21 +41,21 @@ func ValidateHandlerInputs(inputs ...interface{}) (err error) {
 		return errors.New("missing handler(s)")
 	}
 
-	for ; i < len(inputs); i++ {
-		if _, ok = inputs[i].(HandlerCtrl); ok {
-			i--
+	for j := i; j < len(inputs); j++ {
+		if _, ok = inputs[j].(HandlerCtrl); ok {
+			// first element after middlewares and last input
+			if j == i && len(inputs)-1 == j {
+				return errors.New("missing handler(s)")
+			}
+			// not last
+			if len(inputs)-1 != j {
+				return errors.New("a handlerCtrl's can only be at the end of the definition and only one")
+			}
 			break
 		}
 
-		if !isHandler(inputs[i]) {
+		if !isHandler(inputs[j]) {
 			return errors.New("invalid handler signature. General tip: no handlers can use the param type `*disgord.Session`, try `disgord.Session` instead")
-		}
-	}
-
-	// check for extra controllers
-	for j := len(inputs) - 2; j >= i; j-- {
-		if _, ok = inputs[j].(HandlerCtrl); ok {
-			return errors.New("a handlerCtrl's can only be at the end of the definition. Expected a handler")
 		}
 	}
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -7,7 +7,7 @@ import (
 func TestValidateHandlerInputs(t *testing.T) {
 	var testHandler Handler = func() {}
 	var testMiddleware Middleware = func(i interface{}) interface{} { return nil }
-	var testCtrl HandlerCtrl = &Ctrl{Runs: 1}
+	var testCtrl HandlerCtrl = &Ctrl{}
 
 	t.Run("valid", func(t *testing.T) {
 		t.Run("handler", func(t *testing.T) {
@@ -129,7 +129,7 @@ func TestValidateHandlerInputs(t *testing.T) {
 			}
 			t.Fail()
 		})
-		t.Run("ctrl handler", func(t *testing.T) {
+		t.Run("ctrl handler ctrl", func(t *testing.T) {
 			err := ValidateHandlerInputs(testCtrl, testHandler, testCtrl)
 			if err != nil {
 				if err.Error() == "a handlerCtrl's can only be at the end of the definition and only one" {
@@ -158,6 +158,31 @@ func TestValidateHandlerInputs(t *testing.T) {
 			err := ValidateHandlerInputs(testHandler, testInvalidHandler)
 			if err != nil {
 				if err.Error() == "invalid handler signature. General tip: no handlers can use the param type `*disgord.Session`, try `disgord.Session` instead" {
+					return
+				}
+				t.Error(err)
+			}
+			t.Fail()
+		})
+	})
+
+	t.Run("invalid ctrl", func(t *testing.T) {
+		testInvalidCtrl := Ctrl{}
+
+		t.Run("invalidCtrl", func(t *testing.T) {
+			err := ValidateHandlerInputs(testInvalidCtrl)
+			if err != nil {
+				if err.Error() == "want disgord.HandlerCtrl not disgord.Ctrl. Try to use &disgord.Ctrl instead of disgord.Ctrl" {
+					return
+				}
+				t.Error(err)
+			}
+			t.Fail()
+		})
+		t.Run("handler invalidCtrl", func(t *testing.T) {
+			err := ValidateHandlerInputs(testHandler, testInvalidCtrl)
+			if err != nil {
+				if err.Error() == "want disgord.HandlerCtrl not disgord.Ctrl. Try to use &disgord.Ctrl instead of disgord.Ctrl" {
 					return
 				}
 				t.Error(err)

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,168 @@
+package disgord
+
+import (
+	"testing"
+)
+
+func TestValidateHandlerInputs(t *testing.T) {
+	var testHandler Handler = func() {}
+	var testMiddleware Middleware = func(i interface{}) interface{} { return nil }
+	var testCtrl HandlerCtrl = &Ctrl{Runs: 1}
+
+	t.Run("valid", func(t *testing.T) {
+		t.Run("handler", func(t *testing.T) {
+			err := ValidateHandlerInputs(testHandler)
+			if err != nil {
+				t.Error(err)
+			}
+		})
+		t.Run("handler ctrl", func(t *testing.T) {
+			err := ValidateHandlerInputs(testHandler, testCtrl)
+			if err != nil {
+				t.Error(err)
+			}
+		})
+		t.Run("middleware handler", func(t *testing.T) {
+			err := ValidateHandlerInputs(testMiddleware, testHandler)
+			if err != nil {
+				t.Error(err)
+			}
+		})
+		t.Run("all", func(t *testing.T) {
+			err := ValidateHandlerInputs(testMiddleware, testHandler, testCtrl)
+			if err != nil {
+				t.Error(err)
+			}
+		})
+		t.Run("all multiple", func(t *testing.T) {
+			err := ValidateHandlerInputs(testMiddleware, testMiddleware, testMiddleware, testHandler, testHandler, testHandler, testCtrl)
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	})
+
+	t.Run("missingHandler", func(t *testing.T) {
+		t.Run("empty", func(t *testing.T) {
+			err := ValidateHandlerInputs()
+			if err != nil {
+				if err.Error() == "missing handler(s)" {
+					return
+				}
+				t.Error(err)
+			}
+			t.Fail()
+		})
+		t.Run("middleware", func(t *testing.T) {
+			err := ValidateHandlerInputs(testMiddleware)
+			if err != nil {
+				if err.Error() == "missing handler(s)" {
+					return
+				}
+				t.Error(err)
+			}
+			t.Fail()
+		})
+		t.Run("ctrl", func(t *testing.T) {
+			err := ValidateHandlerInputs(testCtrl)
+			if err != nil {
+				if err.Error() == "missing handler(s)" {
+					return
+				}
+				t.Error(err)
+			}
+			t.Fail()
+		})
+		t.Run("middleware ctrl", func(t *testing.T) {
+			err := ValidateHandlerInputs(testMiddleware, testCtrl)
+			if err != nil {
+				if err.Error() == "missing handler(s)" {
+					return
+				}
+				t.Error(err)
+			}
+			t.Fail()
+		})
+	})
+
+	t.Run("middleware", func(t *testing.T) {
+		t.Run("ctrl first", func(t *testing.T) {
+			err := ValidateHandlerInputs(testCtrl, testMiddleware)
+			if err != nil {
+				if err.Error() == "middlewares can only be in the beginning. Grouped together" {
+					return
+				}
+				t.Error(err)
+			}
+			t.Fail()
+		})
+		t.Run("handler first", func(t *testing.T) {
+			err := ValidateHandlerInputs(testHandler, testMiddleware)
+			if err != nil {
+				if err.Error() == "middlewares can only be in the beginning. Grouped together" {
+					return
+				}
+				t.Error(err)
+			}
+			t.Fail()
+		})
+		t.Run("middleware handler middleware", func(t *testing.T) {
+			err := ValidateHandlerInputs(testMiddleware, testHandler, testMiddleware)
+			if err != nil {
+				if err.Error() == "middlewares can only be in the beginning. Grouped together" {
+					return
+				}
+				t.Error(err)
+			}
+			t.Fail()
+		})
+	})
+
+	t.Run("ctrl", func(t *testing.T) {
+		t.Run("multiple ctrl", func(t *testing.T) {
+			err := ValidateHandlerInputs(testMiddleware, testHandler, testCtrl, testCtrl)
+			if err != nil {
+				if err.Error() == "a handlerCtrl's can only be at the end of the definition and only one" {
+					return
+				}
+				t.Error(err)
+			}
+			t.Fail()
+		})
+		t.Run("ctrl handler", func(t *testing.T) {
+			err := ValidateHandlerInputs(testCtrl, testHandler, testCtrl)
+			if err != nil {
+				if err.Error() == "a handlerCtrl's can only be at the end of the definition and only one" {
+					return
+				}
+				t.Error(err)
+			}
+			t.Fail()
+		})
+	})
+
+	t.Run("invalid handler", func(t *testing.T) {
+		testInvalidHandler := func(s Session, mc MessageCreate) {}
+
+		t.Run("invalidHandler", func(t *testing.T) {
+			err := ValidateHandlerInputs(testInvalidHandler)
+			if err != nil {
+				if err.Error() == "invalid handler signature. General tip: no handlers can use the param type `*disgord.Session`, try `disgord.Session` instead" {
+					return
+				}
+				t.Error(err)
+			}
+			t.Fail()
+		})
+		t.Run("handler invalidHandler", func(t *testing.T) {
+			err := ValidateHandlerInputs(testHandler, testInvalidHandler)
+			if err != nil {
+				if err.Error() == "invalid handler signature. General tip: no handlers can use the param type `*disgord.Session`, try `disgord.Session` instead" {
+					return
+				}
+				t.Error(err)
+			}
+			t.Fail()
+		})
+	})
+}


### PR DESCRIPTION
# Description

This PR adds tests for `ValidateHandlerInputs()` with 100% Coverage and fixes some bugs I've encountered.

The motivation behind this was that a call to `client.On()` with only a `&Ctrl{}` as argument would panic inside of `ValidateHandlerInputs()` due to an out of range error.
Now it just errors.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
