### PR TITLE
Add the ability to pass through a function (CacheInitializer) to init a custom cache

### DIFF
--- a/client.go
+++ b/client.go
@@ -89,7 +89,11 @@ func createClient(conf *Config) (c *Client, err error) {
 		if conf.CacheConfig == nil {
 			conf.CacheConfig = &CacheConfig{}
 		}
-		cacher, err = newCache(conf.CacheConfig)
+		f := newCache
+		if conf.CacheInitializer != nil {
+			f = conf.CacheInitializer
+		}
+		cacher, err = f(conf.CacheConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -172,6 +176,10 @@ type Config struct {
 	// Logger is a dependency that must be injected to support logging.
 	// disgord.DefaultLogger() can be used
 	Logger Logger
+
+	// CacheInitializer defines a function which can be used to create a cache.
+	// For most use cases, you will not need to set this because the built in cache will be sufficient.
+	CacheInitializer func(conf *CacheConfig) (c *Cache, err error)
 
 	// ################################################
 	// ##

--- a/disgord.go
+++ b/disgord.go
@@ -111,7 +111,7 @@
 //
 // > Note: if you create a CacheConfig you don't have to set every field.
 //
-// > Note: Only LFU is supported.
+// > Note: Only LFU is supported with the default cache.
 //
 // > Note: Lifetime options does not currently work/do anything (yet).
 //
@@ -133,7 +133,7 @@
 //           },
 //  })
 //
-// If you just want to change a specific field, you can do so. The fields are always default values.
+// If you just want to change a specific field, you can do so. The fields are always default values. If you wish to implement a custom cache, you can simply set the CacheInitializer parameter in the client config to a function which initialises the custom cache.
 //
 // > Note: Disabling caching for some types while activating it for others (eg. disabling channels, but activating guild caching), can cause items extracted from the cache to not reflect the true discord state.
 //


### PR DESCRIPTION
## Description

Allows for the user to insert a function which will be used to initialise the cache. This is useful because whilst the cache built into disgord will suffice for most use cases, there are situations where you might want to build your own cache (and can't right now because `cache` is protected).

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# Checklist:

- [X] I ran `go generate`
- [X] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [N/A] Added benchmarks if this is a performant required component (potential bottlenecks)
