### PR TITLE
implement extremely relaxed emoji matching in hash calculation

### DIFF
--- a/internal/httd/client.go
+++ b/internal/httd/client.go
@@ -21,7 +21,7 @@ const (
 
 	RegexpSnowflakes     = `([0-9]+)`
 	RegexpURLSnowflakes  = `\/` + RegexpSnowflakes + `\/?`
-	RegexpEmoji          = `(\x{D83C}-\x{DFFF}|\x{1F600}-\x{1F6FF}|[\x{2600}-\x{26FF}]|\:[a-zA-Z0-9_]+\:|[a-zA-Z0-9_]+\:[0-9]+)\s?`
+	RegexpEmoji          = `([.^/]+)\s?`
 	RegexpReactionPrefix = `\/channels\/([0-9]+)\/messages\/\{id\}\/reactions\/`
 
 	// Header

--- a/internal/httd/request_test.go
+++ b/internal/httd/request_test.go
@@ -36,6 +36,7 @@ func TestRequest_RateLimitID(t *testing.T) {
 		"/channels/540519296640614416/messages/540519319814275089/reactions/🥰/@me":                                                               "GET:/channels/540519296640614416/messages/{id}/reactions/{emoji}/@me",
 		"/channels/486833611564253186/messages/540519319814275089/reactions/🥺/@me":                                                               "GET:/channels/486833611564253186/messages/{id}/reactions/{emoji}/@me",
 		"/channels/486833611564253186/messages/540519319814275089/reactions/🥺 /@me":                                                              "GET:/channels/486833611564253186/messages/{id}/reactions/{emoji}/@me",
+		"/channels/486833611564253186/messages/540519319814275089/reactions/♀️/@me":                                                              "GET:/channels/486833611564253186/messages/{id}/reactions/{emoji}/@me",
 		"/channels/486833611564253186/messages/540519319814275089/reactions/:smiling_face_with_3_hearts:/@me":                                    "GET:/channels/486833611564253186/messages/{id}/reactions/{emoji}/@me",
 		"/channels/486833611564253186/messages/540519319814275089/reactions/:smiling_face_with_3_hearts:":                                        "GET:/channels/486833611564253186/messages/{id}/reactions/{emoji}",
 		"/channels/486833611564253186/messages/540519319814275089/reactions/:smiling_face_with_3_hearts:/":                                       "GET:/channels/486833611564253186/messages/{id}/reactions/{emoji}",


### PR DESCRIPTION
# Description

Changed the regular expression for matching emoji's to make it much more relaxed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I ran `go generate`
- [ ] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
