### PR TITLE
Change discord domain references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Example (use spaces):
 //                          Gateway event.
 // Endpoint                 /guilds
 // Rate limiter             /guilds
-// Discord documentation    https://discordapp.com/developers/docs/resources/guild#create-guild
+// Discord documentation    https://discord.com/developers/docs/resources/guild#create-guild
 // Reviewed                 2018-08-16
 // Comment                  This endpoint can be used only by bots in less than 10 guilds. Creating channel
 //                          categories from this endpoint is not supported.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Remember to read the docs/code for whatever version of disgord you are using. Th
 
 > Examples can be found in [docs/examples](docs/examples) and some open source projects Disgord projects in the [wiki](https://github.com/andersfylling/disgord/wiki/A-few-Disgord-Projects)
 
-I highly suggest reading the [Discord API documentation](https://discordapp.com/developers/docs/intro) and the [Disgord go doc](https://pkg.go.dev/github.com/andersfylling/disgord?tab=doc).
+I highly suggest reading the [Discord API documentation](https://discord.com/developers/docs/intro) and the [Disgord go doc](https://pkg.go.dev/github.com/andersfylling/disgord?tab=doc).
 
 Here is a basic bot program that prints out every message. Save it as `main.go`, run `go mod init bot` and `go mod download`. You can then start the bot by writing `go run .`
 
@@ -168,7 +168,7 @@ Yes. See guild.go. The permission consts are pretty much a copy from DiscordGo.
 5. Will Disgord support self bots?
 
 No. Self bots are againts ToS and could result in account termination (see
-https://support.discordapp.com/hc/en-us/articles/115002192352-Automated-user-accounts-self-bots-). 
+https://support.discord.com/hc/en-us/articles/115002192352-Automated-user-accounts-self-bots-). 
 In addition, self bots aren't a part of the official Discord API, meaning support could change at any 
 time and Disgord could break unexpectedly if this feature were to be added.
 ```

--- a/auditlog.go
+++ b/auditlog.go
@@ -322,7 +322,7 @@ func auditLogFactory() interface{} {
 // Note that this request will _always_ send a REST request, regardless of you calling IgnoreCache or not.
 //  Method                   GET
 //  Endpoint                 /guilds/{guild.id}/audit-logs
-//  Discord documentation    https://discordapp.com/developers/docs/resources/audit-log#get-guild-audit-log
+//  Discord documentation    https://discord.com/developers/docs/resources/audit-log#get-guild-audit-log
 //  Reviewed                 2018-06-05
 //  Comment                  -
 //  Note                     Check the last entry in the cacheLink, to avoid fetching data we already got

--- a/channel.go
+++ b/channel.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Channel types
-// https://discordapp.com/developers/docs/resources/channel#channel-object-channel-types
+// https://discord.com/developers/docs/resources/channel#channel-object-channel-types
 const (
 	ChannelTypeGuildText uint = iota
 	ChannelTypeDM
@@ -25,7 +25,7 @@ const (
 	ChannelTypeGuildStore
 )
 
-// Attachment https://discordapp.com/developers/docs/resources/channel#attachment-object
+// Attachment https://discord.com/developers/docs/resources/channel#attachment-object
 type Attachment struct {
 	ID       Snowflake `json:"id"`
 	Filename string    `json:"filename"`
@@ -59,7 +59,7 @@ func (a *Attachment) DeepCopy() (copy interface{}) {
 	return
 }
 
-// PermissionOverwrite https://discordapp.com/developers/docs/resources/channel#overwrite-object
+// PermissionOverwrite https://discord.com/developers/docs/resources/channel#overwrite-object
 type PermissionOverwrite struct {
 	ID    Snowflake      `json:"id"`    // role or user id
 	Type  string         `json:"type"`  // either `role` or `member`
@@ -316,7 +316,7 @@ func (c *Channel) SendMsg(ctx context.Context, client MessageSender, message *Me
 // GetChannel [REST] Get a channel by Snowflake. Returns a channel object.
 //  Method                  GET
 //  Endpoint                /channels/{channel.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#get-channel
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#get-channel
 //  Reviewed                2018-06-07
 //  Comment                 -
 func (c *Client) GetChannel(ctx context.Context, channelID Snowflake, flags ...Flag) (ret *Channel, err error) {
@@ -344,7 +344,7 @@ func (c *Client) GetChannel(ctx context.Context, channelID Snowflake, flags ...F
 // For the PATCH method, all the JSON Params are optional.
 //  Method                  PUT/PATCH
 //  Endpoint                /channels/{channel.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#modify-channel
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#modify-channel
 //  Reviewed                2018-06-07
 //  Comment                 andersfylling: only implemented the patch method, as its parameters are optional.
 func (c *Client) UpdateChannel(ctx context.Context, channelID Snowflake, flags ...Flag) (builder *updateChannelBuilder) {
@@ -371,7 +371,7 @@ func (c *Client) UpdateChannel(ctx context.Context, channelID Snowflake, flags .
 // Fires a Channel Delete Gateway event.
 //  Method                  Delete
 //  Endpoint                /channels/{channel.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#deleteclose-channel
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#deleteclose-channel
 //  Reviewed                2018-10-09
 //  Comment                 Deleting a guild channel cannot be undone. Use this with caution, as it
 //                          is impossible to undo this action when performed on a guild channel. In
@@ -400,7 +400,7 @@ func (c *Client) DeleteChannel(ctx context.Context, channelID Snowflake, flags .
 	return getChannel(r.Execute)
 }
 
-// UpdateChannelPermissionsParams https://discordapp.com/developers/docs/resources/channel#edit-channel-permissions-json-params
+// UpdateChannelPermissionsParams https://discord.com/developers/docs/resources/channel#edit-channel-permissions-json-params
 type UpdateChannelPermissionsParams struct {
 	Allow PermissionBits `json:"allow"` // the bitwise value of all allowed permissions
 	Deny  PermissionBits `json:"deny"`  // the bitwise value of all disallowed permissions
@@ -412,7 +412,7 @@ type UpdateChannelPermissionsParams struct {
 // For more information about permissions, see permissions.
 //  Method                  PUT
 //  Endpoint                /channels/{channel.id}/permissions/{overwrite.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#edit-channel-permissions
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#edit-channel-permissions
 //  Reviewed                2018-06-07
 //  Comment                 -
 func (c *Client) UpdateChannelPermissions(ctx context.Context, channelID, overwriteID Snowflake, params *UpdateChannelPermissionsParams, flags ...Flag) (err error) {
@@ -444,7 +444,7 @@ func (c *Client) UpdateChannelPermissions(ctx context.Context, channelID, overwr
 // guild channels. Requires the 'MANAGE_CHANNELS' permission.
 //  Method                  GET
 //  Endpoint                /channels/{channel.id}/invites
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#get-channel-invites
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#get-channel-invites
 //  Reviewed                2018-06-07
 //  Comment                 -
 func (c *Client) GetChannelInvites(ctx context.Context, channelID Snowflake, flags ...Flag) (invites []*Invite, err error) {
@@ -466,7 +466,7 @@ func (c *Client) GetChannelInvites(ctx context.Context, channelID Snowflake, fla
 	return getInvites(r.Execute)
 }
 
-// CreateChannelInvitesParams https://discordapp.com/developers/docs/resources/channel#create-channel-invite-json-params
+// CreateChannelInvitesParams https://discord.com/developers/docs/resources/channel#create-channel-invite-json-params
 type CreateChannelInvitesParams struct {
 	MaxAge    int  `json:"max_age,omitempty"`   // duration of invite in seconds before expiry, or 0 for never. default 86400 (24 hours)
 	MaxUses   int  `json:"max_uses,omitempty"`  // max number of uses or 0 for unlimited. default 0
@@ -482,7 +482,7 @@ type CreateChannelInvitesParams struct {
 // not. If you are not sending any fields, you still have to send an empty JSON object ({}). Returns an invite object.
 //  Method                  POST
 //  Endpoint                /channels/{channel.id}/invites
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#create-channel-invite
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#create-channel-invite
 //  Reviewed                2018-06-07
 //  Comment                 -
 func (c *Client) CreateChannelInvites(ctx context.Context, channelID Snowflake, params *CreateChannelInvitesParams, flags ...Flag) (ret *Invite, err error) {
@@ -511,10 +511,10 @@ func (c *Client) CreateChannelInvites(ctx context.Context, channelID Snowflake, 
 
 // DeleteChannelPermission [REST] Delete a channel permission overwrite for a user or role in a channel. Only usable
 // for guild channels. Requires the 'MANAGE_ROLES' permission. Returns a 204 empty response on success. For more
-// information about permissions, see permissions: https://discordapp.com/developers/docs/topics/permissions#permissions
+// information about permissions, see permissions: https://discord.com/developers/docs/topics/permissions#permissions
 //  Method                  DELETE
 //  Endpoint                /channels/{channel.id}/permissions/{overwrite.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#delete-channel-permission
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#delete-channel-permission
 //  Reviewed                2018-06-07
 //  Comment                 -
 func (c *Client) DeleteChannelPermission(ctx context.Context, channelID, overwriteID Snowflake, flags ...Flag) (err error) {
@@ -565,7 +565,7 @@ func (g *GroupDMParticipant) FindErrors() error {
 // on success.
 //  Method                  PUT
 //  Endpoint                /channels/{channel.id}/recipients/{user.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#group-dm-add-recipient
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#group-dm-add-recipient
 //  Reviewed                2018-06-10
 //  Comment                 -
 func (c *Client) AddDMParticipant(ctx context.Context, channelID Snowflake, participant *GroupDMParticipant, flags ...Flag) error {
@@ -595,7 +595,7 @@ func (c *Client) AddDMParticipant(ctx context.Context, channelID Snowflake, part
 // KickParticipant [REST] Removes a recipient from a Group DM. Returns a 204 empty response on success.
 //  Method                  DELETE
 //  Endpoint                /channels/{channel.id}/recipients/{user.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#group-dm-remove-recipient
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#group-dm-remove-recipient
 //  Reviewed                2018-06-10
 //  Comment                 -
 func (c *Client) KickParticipant(ctx context.Context, channelID, userID Snowflake, flags ...Flag) (err error) {
@@ -623,7 +623,7 @@ func (c *Client) KickParticipant(ctx context.Context, channelID, userID Snowflak
 //
 //////////////////////////////////////////////////////
 
-// updateChannelBuilder https://discordapp.com/developers/docs/resources/channel#modify-channel-json-params
+// updateChannelBuilder https://discord.com/developers/docs/resources/channel#modify-channel-json-params
 //generate-rest-params: parent_id:Snowflake, permission_overwrites:[]PermissionOverwrite, user_limit:uint, bitrate:uint, rate_limit_per_user:uint, nsfw:bool, topic:string, position:int, name:string,
 //generate-rest-basic-execute: channel:*Channel,
 type updateChannelBuilder struct {

--- a/client.go
+++ b/client.go
@@ -292,7 +292,7 @@ func (c *Client) InviteURL(ctx context.Context) (u string, err error) {
 		return "", disgorderr.Wrap(err, "can't create invite url without fetching the bot id")
 	}
 
-	format := "https://discordapp.com/oauth2/authorize?scope=bot&client_id=%s&permissions=%d"
+	format := "https://discord.com/oauth2/authorize?scope=bot&client_id=%s&permissions=%d"
 	u = fmt.Sprintf(format, c.myID.String(), c.permissions)
 	return u, nil
 }

--- a/client.go
+++ b/client.go
@@ -80,7 +80,7 @@ func createClient(conf *Config) (c *Client, err error) {
 		conf.Logger = logger.Empty{}
 	}
 
-	// ignore PRESENCES_REPLACE: https://github.com/discordapp/discord-api-docs/issues/683
+	// ignore PRESENCES_REPLACE: https://github.com/discord/discord-api-docs/issues/683
 	conf.IgnoreEvents = append(conf.IgnoreEvents, "PRESENCES_REPLACE")
 
 	// caching

--- a/docs/examples/sharding.md
+++ b/docs/examples/sharding.md
@@ -1,6 +1,6 @@
 > NOTE! outdated: sharding is handled automatically now. Use disgord.ShardConfig.
 
-Disgord supports the use of sharding for as explained here: [discordapp.com/.../gateway#sharding](https://discordapp.com/developers/docs/topics/gateway#sharding)
+Disgord supports the use of sharding for as explained here: [discord.com/.../gateway#sharding](https://discord.com/developers/docs/topics/gateway#sharding)
 
 Disgord uses an internal shard manager to handle this for you. However, you can customize this and should have enough control to handle sharding across N instances of disgord (see the godoc).
 

--- a/embed.go
+++ b/embed.go
@@ -4,10 +4,10 @@ import (
 	"github.com/andersfylling/disgord/internal/constant"
 )
 
-// limitations: https://discordapp.com/developers/docs/resources/channel#embed-limits
+// limitations: https://discord.com/developers/docs/resources/channel#embed-limits
 // TODO: implement NewEmbedX functions that ensures limitations
 
-// Embed https://discordapp.com/developers/docs/resources/channel#embed-object
+// Embed https://discord.com/developers/docs/resources/channel#embed-object
 type Embed struct {
 	Lockable `json:"-"`
 
@@ -86,7 +86,7 @@ func (c *Embed) CopyOverTo(other interface{}) (err error) {
 	return nil
 }
 
-// EmbedThumbnail https://discordapp.com/developers/docs/resources/channel#embed-object-embed-thumbnail-structure
+// EmbedThumbnail https://discord.com/developers/docs/resources/channel#embed-object-embed-thumbnail-structure
 type EmbedThumbnail struct {
 	Lockable `json:"-"`
 
@@ -130,7 +130,7 @@ func (c *EmbedThumbnail) CopyOverTo(other interface{}) (err error) {
 	return
 }
 
-// EmbedVideo https://discordapp.com/developers/docs/resources/channel#embed-object-embed-video-structure
+// EmbedVideo https://discord.com/developers/docs/resources/channel#embed-object-embed-video-structure
 type EmbedVideo struct {
 	Lockable `json:"-"`
 
@@ -172,7 +172,7 @@ func (c *EmbedVideo) CopyOverTo(other interface{}) (err error) {
 	return nil
 }
 
-// EmbedImage https://discordapp.com/developers/docs/resources/channel#embed-object-embed-image-structure
+// EmbedImage https://discord.com/developers/docs/resources/channel#embed-object-embed-image-structure
 type EmbedImage struct {
 	Lockable `json:"-"`
 
@@ -216,7 +216,7 @@ func (c *EmbedImage) CopyOverTo(other interface{}) (err error) {
 	return nil
 }
 
-// EmbedProvider https://discordapp.com/developers/docs/resources/channel#embed-object-embed-provider-structure
+// EmbedProvider https://discord.com/developers/docs/resources/channel#embed-object-embed-provider-structure
 type EmbedProvider struct {
 	Lockable `json:"-"`
 
@@ -256,7 +256,7 @@ func (c *EmbedProvider) CopyOverTo(other interface{}) (err error) {
 	return nil
 }
 
-// EmbedAuthor https://discordapp.com/developers/docs/resources/channel#embed-object-embed-author-structure
+// EmbedAuthor https://discord.com/developers/docs/resources/channel#embed-object-embed-author-structure
 type EmbedAuthor struct {
 	Lockable `json:"-"`
 
@@ -300,7 +300,7 @@ func (c *EmbedAuthor) CopyOverTo(other interface{}) (err error) {
 	return nil
 }
 
-// EmbedFooter https://discordapp.com/developers/docs/resources/channel#embed-object-embed-footer-structure
+// EmbedFooter https://discord.com/developers/docs/resources/channel#embed-object-embed-footer-structure
 type EmbedFooter struct {
 	Lockable `json:"-"`
 
@@ -342,7 +342,7 @@ func (c *EmbedFooter) CopyOverTo(other interface{}) (err error) {
 	return nil
 }
 
-// EmbedField https://discordapp.com/developers/docs/resources/channel#embed-object-embed-field-structure
+// EmbedField https://discord.com/developers/docs/resources/channel#embed-object-embed-field-structure
 type EmbedField struct {
 	Lockable `json:"-"`
 

--- a/emoji.go
+++ b/emoji.go
@@ -173,7 +173,7 @@ func cacheEmoji_SetAll(cache Cacher, guildID Snowflake, emojis []*Emoji) error {
 //
 // REST Methods
 //
-// https://discordapp.com/developers/docs/resources/emoji#emoji-resource
+// https://discord.com/developers/docs/resources/emoji#emoji-resource
 // Routes for controlling emojis do not follow the normal rate limit conventions.
 // These routes are specifically limited on a per-guild basis to prevent abuse.
 // This means that the quota returned by our APIs may be inaccurate,
@@ -184,7 +184,7 @@ func cacheEmoji_SetAll(cache Cacher, guildID Snowflake, emojis []*Emoji) error {
 // GetGuildEmoji [REST] Returns an emoji object for the given guild and emoji IDs.
 //  Method                  GET
 //  Endpoint                /guilds/{guild.id}/emojis/{emoji.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/emoji#get-guild-emoji
+//  Discord documentation   https://discord.com/developers/docs/resources/emoji#get-guild-emoji
 //  Reviewed                2019-02-20
 //  Comment                 -
 func (c *Client) GetGuildEmoji(ctx context.Context, guildID, emojiID Snowflake, flags ...Flag) (*Emoji, error) {
@@ -207,7 +207,7 @@ func (c *Client) GetGuildEmoji(ctx context.Context, guildID, emojiID Snowflake, 
 // GetGuildEmojis [REST] Returns a list of emoji objects for the given guild.
 //  Method                  GET
 //  Endpoint                /guilds/{guild.id}/emojis
-//  Discord documentation   https://discordapp.com/developers/docs/resources/emoji#list-guild-emojis
+//  Discord documentation   https://discord.com/developers/docs/resources/emoji#list-guild-emojis
 //  Reviewed                2018-06-10
 //  Comment                 -
 func (c *Client) GetGuildEmojis(ctx context.Context, guildID Snowflake, flags ...Flag) (emojis []*Emoji, err error) {
@@ -259,7 +259,7 @@ type CreateGuildEmojiParams struct {
 // Returns the new emoji object on success. Fires a Guild Emojis Update Gateway event.
 //  Method                  POST
 //  Endpoint                /guilds/{guild.id}/emojis
-//  Discord documentation   https://discordapp.com/developers/docs/resources/emoji#create-guild-emoji
+//  Discord documentation   https://discord.com/developers/docs/resources/emoji#create-guild-emoji
 //  Reviewed                2019-02-20
 //  Comment                 Emojis and animated emojis have a maximum file size of 256kb. Attempting to upload
 //                          an emoji larger than this limit will fail and return 400 Bad Request and an
@@ -300,7 +300,7 @@ func (c *Client) CreateGuildEmoji(ctx context.Context, guildID Snowflake, params
 // Returns the updated emoji object on success. Fires a Guild Emojis Update Gateway event.
 //  Method                  PATCH
 //  Endpoint                /guilds/{guild.id}/emojis/{emoji.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/emoji#modify-guild-emoji
+//  Discord documentation   https://discord.com/developers/docs/resources/emoji#modify-guild-emoji
 //  Reviewed                2019-02-20
 //  Comment                 -
 func (c *Client) UpdateGuildEmoji(ctx context.Context, guildID, emojiID Snowflake, flags ...Flag) (builder *updateGuildEmojiBuilder) {
@@ -328,7 +328,7 @@ func (c *Client) UpdateGuildEmoji(ctx context.Context, guildID, emojiID Snowflak
 // success. Fires a Guild Emojis Update Gateway event.
 //  Method                  DELETE
 //  Endpoint                /guilds/{guild.id}/emojis/{emoji.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/emoji#delete-guild-emoji
+//  Discord documentation   https://discord.com/developers/docs/resources/emoji#delete-guild-emoji
 //  Reviewed                2018-06-10
 //  Comment                 -
 func (c *Client) DeleteGuildEmoji(ctx context.Context, guildID, emojiID Snowflake, flags ...Flag) (err error) {

--- a/generate/discorddocs/README.md
+++ b/generate/discorddocs/README.md
@@ -3,4 +3,4 @@ As this rarely changes, it should not be possible to trigger this with `go gener
 
 
 URL it depends on for page scraping (alternative is to clone the github repo):
-https://discordapp.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags
+https://discord.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags

--- a/generate/discorddocs/main.go
+++ b/generate/discorddocs/main.go
@@ -42,7 +42,7 @@ func genPermissions() {
 	var err error
 	var done bool
 	httpTimeout := 3 * time.Second
-	tableURL := "https://discordapp.com/developers/docs/topics/permissions"
+	tableURL := "https://discord.com/developers/docs/topics/permissions"
 
 	c := newScraper()
 

--- a/guild.go
+++ b/guild.go
@@ -173,7 +173,7 @@ type PartialGuild = Guild // TODO: find the actual data struct for partial guild
 
 // Guild Guilds in Discord represent an isolated collection of users and channels,
 //  and are often referred to as "servers" in the UI.
-// https://discordapp.com/developers/docs/resources/guild#guild-object
+// https://discord.com/developers/docs/resources/guild#guild-object
 // Fields with `*` are only sent within the GUILD_CREATE event
 // reviewed: 2018-08-25
 type Guild struct {
@@ -831,7 +831,7 @@ func (p *PartialBan) String() string {
 	return fmt.Sprintf("mod{%d} banned member{%d}, reason: %s.", p.ModeratorResponsibleID, p.BannedUserID, p.Reason)
 }
 
-// Ban https://discordapp.com/developers/docs/resources/guild#ban-object
+// Ban https://discord.com/developers/docs/resources/guild#ban-object
 type Ban struct {
 	Lockable `json:"-"`
 
@@ -877,7 +877,7 @@ func (b *Ban) CopyOverTo(other interface{}) (err error) {
 
 // ------------
 
-// GuildEmbed https://discordapp.com/developers/docs/resources/guild#guild-embed-object
+// GuildEmbed https://discord.com/developers/docs/resources/guild#guild-embed-object
 type GuildEmbed struct {
 	Lockable `json:"-"`
 
@@ -920,7 +920,7 @@ func (e *GuildEmbed) CopyOverTo(other interface{}) (err error) {
 
 // -------
 
-// Integration https://discordapp.com/developers/docs/resources/guild#integration-object
+// Integration https://discord.com/developers/docs/resources/guild#integration-object
 type Integration struct {
 	Lockable `json:"-"`
 
@@ -982,7 +982,7 @@ func (i *Integration) CopyOverTo(other interface{}) (err error) {
 	return
 }
 
-// IntegrationAccount https://discordapp.com/developers/docs/resources/guild#integration-account-object
+// IntegrationAccount https://discord.com/developers/docs/resources/guild#integration-account-object
 type IntegrationAccount struct {
 	Lockable `json:"-"`
 
@@ -1025,7 +1025,7 @@ func (i *IntegrationAccount) CopyOverTo(other interface{}) (err error) {
 
 // -------
 
-// Member https://discordapp.com/developers/docs/resources/guild#guild-member-object
+// Member https://discord.com/developers/docs/resources/guild#guild-member-object
 type Member struct {
 	Lockable `json:"-"`
 
@@ -1157,7 +1157,7 @@ func (m *Member) CopyOverTo(other interface{}) (err error) {
 //////////////////////////////////////////////////////
 
 // CreateGuildParams ...
-// https://discordapp.com/developers/docs/resources/guild#create-guild-json-params
+// https://discord.com/developers/docs/resources/guild#create-guild-json-params
 // example partial channel object:
 // {
 //    "name": "naming-things-is-hard",
@@ -1177,7 +1177,7 @@ type CreateGuildParams struct {
 // CreateGuild [REST] Create a new guild. Returns a guild object on success. Fires a Guild Create Gateway event.
 //  Method                  POST
 //  Endpoint                /guilds
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#create-guild
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#create-guild
 //  Reviewed                2018-08-16
 //  Comment                 This endpoint. can be used only by bots in less than 10 guilds. Creating channel
 //                          categories from this endpoint. is not supported.
@@ -1216,7 +1216,7 @@ func (c *Client) CreateGuild(ctx context.Context, guildName string, params *Crea
 // GetGuild [REST] Returns the guild object for the given id.
 //  Method                  GET
 //  Endpoint                /guilds/{guild.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#get-guild
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#get-guild
 //  Reviewed                2018-08-17
 //  Comment                 -
 func (c *Client) GetGuild(ctx context.Context, id Snowflake, flags ...Flag) (guild *Guild, err error) {
@@ -1237,7 +1237,7 @@ func (c *Client) GetGuild(ctx context.Context, id Snowflake, flags ...Flag) (gui
 // object on success. Fires a Guild Update Gateway event.
 //  Method                  PATCH
 //  Endpoint                /guilds/{guild.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#modify-guild
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#modify-guild
 //  Reviewed                2018-08-17
 //  Comment                 All parameters to this endpoint. are optional
 func (c *Client) UpdateGuild(ctx context.Context, id Snowflake, flags ...Flag) (builder *updateGuildBuilder) {
@@ -1262,7 +1262,7 @@ func (c *Client) UpdateGuild(ctx context.Context, id Snowflake, flags ...Flag) (
 // Fires a Guild Delete Gateway event.
 //  Method                  DELETE
 //  Endpoint                /guilds/{guild.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#delete-guild
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#delete-guild
 //  Reviewed                2018-08-17
 //  Comment                 -
 func (c *Client) DeleteGuild(ctx context.Context, id Snowflake, flags ...Flag) (err error) {
@@ -1280,7 +1280,7 @@ func (c *Client) DeleteGuild(ctx context.Context, id Snowflake, flags ...Flag) (
 // GetGuildChannels [REST] Returns a list of guild channel objects.
 //  Method                  GET
 //  Endpoint                /guilds/{guild.id}/channels
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#get-guild-channels
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#get-guild-channels
 //  Reviewed                2018-08-17
 //  Comment                 -
 func (c *Client) GetGuildChannels(ctx context.Context, guildID Snowflake, flags ...Flag) (ret []*Channel, err error) {
@@ -1298,7 +1298,7 @@ func (c *Client) GetGuildChannels(ctx context.Context, guildID Snowflake, flags 
 	return getChannels(r.Execute)
 }
 
-// CreateGuildChannelParams https://discordapp.com/developers/docs/resources/guild#create-guild-channel-json-params
+// CreateGuildChannelParams https://discord.com/developers/docs/resources/guild#create-guild-channel-json-params
 type CreateGuildChannelParams struct {
 	Name                 string                `json:"name"` // required
 	Type                 uint                  `json:"type,omitempty"`
@@ -1319,7 +1319,7 @@ type CreateGuildChannelParams struct {
 // Returns the new channel object on success. Fires a Channel Create Gateway event.
 //  Method                  POST
 //  Endpoint                /guilds/{guild.id}/channels
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#create-guild-channel
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#create-guild-channel
 //  Reviewed                2018-08-17
 //  Comment                 All parameters for this endpoint. are optional excluding 'name'
 func (c *Client) CreateGuildChannel(ctx context.Context, guildID Snowflake, channelName string, params *CreateGuildChannelParams, flags ...Flag) (ret *Channel, err error) {
@@ -1355,7 +1355,7 @@ func (c *Client) CreateGuildChannel(ctx context.Context, guildID Snowflake, chan
 }
 
 // UpdateGuildChannelPositionsParams ...
-// https://discordapp.com/developers/docs/resources/guild#modify-guild-channel-positions-json-params
+// https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions-json-params
 type UpdateGuildChannelPositionsParams struct {
 	ID       Snowflake `json:"id"`
 	Position int       `json:"position"`
@@ -1371,7 +1371,7 @@ type UpdateGuildChannelPositionsParams struct {
 // Gateway events.
 //  Method                  PATCH
 //  Endpoint                /guilds/{guild.id}/channels
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#modify-guild-channel-positions
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions
 //  Reviewed                2018-08-17
 //  Comment                 Only channels to be modified are required, with the minimum being a swap
 //                          between at least two channels.
@@ -1411,7 +1411,7 @@ func NewUpdateGuildRolePositionsParams(rs []*Role) (p []UpdateGuildRolePositions
 }
 
 // UpdateGuildRolePositionsParams ...
-// https://discordapp.com/developers/docs/resources/guild#modify-guild-role-positions-json-params
+// https://discord.com/developers/docs/resources/guild#modify-guild-role-positions-json-params
 type UpdateGuildRolePositionsParams struct {
 	ID       Snowflake `json:"id"`
 	Position int       `json:"position"`
@@ -1425,7 +1425,7 @@ type UpdateGuildRolePositionsParams struct {
 // Fires multiple Guild Role Update Gateway events.
 //  Method                  PATCH
 //  Endpoint                /guilds/{guild.id}/roles
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#modify-guild-role-positions
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#modify-guild-role-positions
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) UpdateGuildRolePositions(ctx context.Context, guildID Snowflake, params []UpdateGuildRolePositionsParams, flags ...Flag) (roles []*Role, err error) {
@@ -1500,7 +1500,7 @@ func (c *Client) UpdateGuildRolePositions(ctx context.Context, guildID Snowflake
 // GetMember [REST] Returns a guild member object for the specified user.
 //  Method                  GET
 //  Endpoint                /guilds/{guild.id}/members/{user.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#get-guild-member
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#get-guild-member
 //  Reviewed                2018-08-17
 //  Comment                 -
 func (c *Client) GetMember(ctx context.Context, guildID, userID Snowflake, flags ...Flag) (ret *Member, err error) {
@@ -1535,11 +1535,11 @@ func (g *getGuildMembersParams) FindErrors() error {
 // refers to the highest snowflake.
 //  Method                  GET
 //  Endpoint                /guilds/{guild.id}/members
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#get-guild-members
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#get-guild-members
 //  Reviewed                2018-08-17
 //  Comment                 All parameters to this endpoint. are optional
 //  Comment#2               "List Guild Members"
-//  Comment#3               https://discordapp.com/developers/docs/resources/guild#list-guild-members-query-string-params
+//  Comment#3               https://discord.com/developers/docs/resources/guild#list-guild-members-query-string-params
 func (c *Client) getGuildMembers(ctx context.Context, guildID Snowflake, params *getGuildMembersParams, flags ...Flag) (ret []*Member, err error) {
 	if params == nil {
 		params = &getGuildMembersParams{}
@@ -1635,7 +1635,7 @@ func (c *Client) GetMembers(ctx context.Context, guildID Snowflake, params *GetM
 }
 
 // AddGuildMemberParams ...
-// https://discordapp.com/developers/docs/resources/guild#add-guild-member-json-params
+// https://discord.com/developers/docs/resources/guild#add-guild-member-json-params
 type AddGuildMemberParams struct {
 	AccessToken string      `json:"access_token"` // required
 	Nick        string      `json:"nick,omitempty"`
@@ -1650,7 +1650,7 @@ type AddGuildMemberParams struct {
 // CREATE_INSTANT_INVITE permission.
 //  Method                  PUT
 //  Endpoint                /guilds/{guild.id}/members/{user.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#add-guild-member
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#add-guild-member
 //  Reviewed                2018-08-18
 //  Comment                 All parameters to this endpoint. except for access_token are optional.
 func (c *Client) AddGuildMember(ctx context.Context, guildID, userID Snowflake, accessToken string, params *AddGuildMemberParams, flags ...Flag) (member *Member, err error) {
@@ -1691,7 +1691,7 @@ func (c *Client) AddGuildMember(ctx context.Context, guildID, userID Snowflake, 
 // Fires a Guild Member Update Gateway event.
 //  Method                  PATCH
 //  Endpoint                /guilds/{guild.id}/members/{user.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#modify-guild-member
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#modify-guild-member
 //  Reviewed                2018-08-17
 //  Comment                 All parameters to this endpoint. are optional. When moving members to channels,
 //                          the API user must have permissions to both connect to the channel and have the
@@ -1723,7 +1723,7 @@ func (c *Client) UpdateGuildMember(ctx context.Context, guildID, userID Snowflak
 // Returns a 204 empty response on success. Fires a Guild Member Update Gateway event.
 //  Method                  PUT
 //  Endpoint                /guilds/{guild.id}/members/{user.id}/roles/{role.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#add-guild-member-role
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#add-guild-member-role
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) AddGuildMemberRole(ctx context.Context, guildID, userID, roleID Snowflake, flags ...Flag) (err error) {
@@ -1742,7 +1742,7 @@ func (c *Client) AddGuildMemberRole(ctx context.Context, guildID, userID, roleID
 // Returns a 204 empty response on success. Fires a Guild Member Update Gateway event.
 //  Method                  DELETE
 //  Endpoint                /guilds/{guild.id}/members/{user.id}/roles/{role.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#remove-guild-member-role
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#remove-guild-member-role
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) RemoveGuildMemberRole(ctx context.Context, guildID, userID, roleID Snowflake, flags ...Flag) (err error) {
@@ -1761,7 +1761,7 @@ func (c *Client) RemoveGuildMemberRole(ctx context.Context, guildID, userID, rol
 // Returns a 204 empty response on success. Fires a Guild Member Remove Gateway event.
 //  Method                  DELETE
 //  Endpoint                /guilds/{guild.id}/members/{user.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#remove-guild-member
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#remove-guild-member
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) KickMember(ctx context.Context, guildID, userID Snowflake, reason string, flags ...Flag) (err error) {
@@ -1780,7 +1780,7 @@ func (c *Client) KickMember(ctx context.Context, guildID, userID Snowflake, reas
 // GetGuildBans [REST] Returns a list of ban objects for the users banned from this guild. Requires the 'BAN_MEMBERS' permission.
 //  Method                  GET
 //  Endpoint                /guilds/{guild.id}/bans
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#get-guild-bans
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#get-guild-bans
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) GetGuildBans(ctx context.Context, id Snowflake, flags ...Flag) (bans []*Ban, err error) {
@@ -1808,7 +1808,7 @@ func (c *Client) GetGuildBans(ctx context.Context, id Snowflake, flags ...Flag) 
 // Requires the 'BAN_MEMBERS' permission.
 //  Method                  GET
 //  Endpoint                /guilds/{guild.id}/bans/{user.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#get-guild-ban
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#get-guild-ban
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) GetGuildBan(ctx context.Context, guildID, userID Snowflake, flags ...Flag) (ret *Ban, err error) {
@@ -1824,7 +1824,7 @@ func (c *Client) GetGuildBan(ctx context.Context, guildID, userID Snowflake, fla
 }
 
 // BanMemberParams ...
-// https://discordapp.com/developers/docs/resources/guild#create-guild-ban-query-string-params
+// https://discord.com/developers/docs/resources/guild#create-guild-ban-query-string-params
 type BanMemberParams struct {
 	DeleteMessageDays int    `urlparam:"delete_message_days,omitempty"` // number of days to delete messages for (0-7)
 	Reason            string `urlparam:"reason,omitempty"`              // reason for being banned
@@ -1843,7 +1843,7 @@ func (b *BanMemberParams) FindErrors() error {
 // the 'BAN_MEMBERS' permission. Returns a 204 empty response on success. Fires a Guild Ban Create Gateway event.
 //  Method                  PUT
 //  Endpoint                /guilds/{guild.id}/bans/{user.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#create-guild-ban
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#create-guild-ban
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) BanMember(ctx context.Context, guildID, userID Snowflake, params *BanMemberParams, flags ...Flag) (err error) {
@@ -1870,7 +1870,7 @@ func (c *Client) BanMember(ctx context.Context, guildID, userID Snowflake, param
 // Returns a 204 empty response on success. Fires a Guild Ban Remove Gateway event.
 //  Method                  DELETE
 //  Endpoint                /guilds/{guild.id}/bans/{user.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#remove-guild-ban
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#remove-guild-ban
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) UnbanMember(ctx context.Context, guildID, userID Snowflake, reason string, flags ...Flag) (err error) {
@@ -1887,7 +1887,7 @@ func (c *Client) UnbanMember(ctx context.Context, guildID, userID Snowflake, rea
 }
 
 // PruneMembersParams will delete members, this is the same as kicking.
-// https://discordapp.com/developers/docs/resources/guild#get-guild-prune-count-query-string-params
+// https://discord.com/developers/docs/resources/guild#get-guild-prune-count-query-string-params
 type pruneMembersParams struct {
 	// Days number of days to count prune for (1 or more)
 	Days int `urlparam:"days"`
@@ -1914,7 +1914,7 @@ type guildPruneCount struct {
 // removed in a prune operation. Requires the 'KICK_MEMBERS' permission.
 //  Method                  GET
 //  Endpoint                /guilds/{guild.id}/prune
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#get-guild-prune-count
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#get-guild-prune-count
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) EstimatePruneMembersCount(ctx context.Context, id Snowflake, days int, flags ...Flag) (estimate int, err error) {
@@ -1952,7 +1952,7 @@ func (c *Client) EstimatePruneMembersCount(ctx context.Context, id Snowflake, da
 // Fires multiple Guild Member Remove Gateway events.
 //  Method                  POST
 //  Endpoint                /guilds/{guild.id}/prune
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#begin-guild-prune
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#begin-guild-prune
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) PruneMembers(ctx context.Context, id Snowflake, days int, reason string, flags ...Flag) (err error) {
@@ -1976,7 +1976,7 @@ func (c *Client) PruneMembers(ctx context.Context, id Snowflake, days int, reaso
 // this returns VIP servers when the guild is VIP-enabled.
 //  Method                  GET
 //  Endpoint                /guilds/{guild.id}/regions
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#get-guild-voice-regions
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#get-guild-voice-regions
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) GetGuildVoiceRegions(ctx context.Context, id Snowflake, flags ...Flag) (ret []*VoiceRegion, err error) {
@@ -1996,7 +1996,7 @@ func (c *Client) GetGuildVoiceRegions(ctx context.Context, id Snowflake, flags .
 // Requires the 'MANAGE_GUILD' permission.
 //  Method                  GET
 //  Endpoint                /guilds/{guild.id}/invites
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#get-guild-invites
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#get-guild-invites
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) GetGuildInvites(ctx context.Context, id Snowflake, flags ...Flag) (ret []*Invite, err error) {
@@ -2016,7 +2016,7 @@ func (c *Client) GetGuildInvites(ctx context.Context, id Snowflake, flags ...Fla
 // Requires the 'MANAGE_GUILD' permission.
 //  Method                   GET
 //  Endpoint                 /guilds/{guild.id}/integrations
-//  Discord documentation    https://discordapp.com/developers/docs/resources/guild#get-guild-integrations
+//  Discord documentation    https://discord.com/developers/docs/resources/guild#get-guild-integrations
 //  Reviewed                 2018-08-18
 //  Comment                  -
 func (c *Client) GetGuildIntegrations(ctx context.Context, id Snowflake, flags ...Flag) (ret []*Integration, err error) {
@@ -2033,7 +2033,7 @@ func (c *Client) GetGuildIntegrations(ctx context.Context, id Snowflake, flags .
 }
 
 // CreateGuildIntegrationParams ...
-// https://discordapp.com/developers/docs/resources/guild#create-guild-integration-json-params
+// https://discord.com/developers/docs/resources/guild#create-guild-integration-json-params
 type CreateGuildIntegrationParams struct {
 	Type string    `json:"type"`
 	ID   Snowflake `json:"id"`
@@ -2044,7 +2044,7 @@ type CreateGuildIntegrationParams struct {
 // Fires a Guild Integrations Update Gateway event.
 //  Method                  POST
 //  Endpoint                /guilds/{guild.id}/integrations
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#create-guild-integration
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#create-guild-integration
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) CreateGuildIntegration(ctx context.Context, guildID Snowflake, params *CreateGuildIntegrationParams, flags ...Flag) (err error) {
@@ -2062,7 +2062,7 @@ func (c *Client) CreateGuildIntegration(ctx context.Context, guildID Snowflake, 
 }
 
 // UpdateGuildIntegrationParams ...
-// https://discordapp.com/developers/docs/resources/guild#modify-guild-integration-json-params
+// https://discord.com/developers/docs/resources/guild#modify-guild-integration-json-params
 // TODO: currently unsure which are required/optional params
 type UpdateGuildIntegrationParams struct {
 	ExpireBehavior    int  `json:"expire_behavior"`
@@ -2075,7 +2075,7 @@ type UpdateGuildIntegrationParams struct {
 // Fires a Guild Integrations Update Gateway event.
 //  Method                  PATCH
 //  Endpoint                /guilds/{guild.id}/integrations/{integration.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#modify-guild-integration
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#modify-guild-integration
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) UpdateGuildIntegration(ctx context.Context, guildID, integrationID Snowflake, params *UpdateGuildIntegrationParams, flags ...Flag) (err error) {
@@ -2097,7 +2097,7 @@ func (c *Client) UpdateGuildIntegration(ctx context.Context, guildID, integratio
 // Fires a Guild Integrations Update Gateway event.
 //  Method                  DELETE
 //  Endpoint                /guilds/{guild.id}/integrations/{integration.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#delete-guild-integration
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#delete-guild-integration
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) DeleteGuildIntegration(ctx context.Context, guildID, integrationID Snowflake, flags ...Flag) (err error) {
@@ -2116,7 +2116,7 @@ func (c *Client) DeleteGuildIntegration(ctx context.Context, guildID, integratio
 // Returns a 204 empty response on success.
 //  Method                  POST
 //  Endpoint                /guilds/{guild.id}/integrations/{integration.id}/sync
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#sync-guild-integration
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#sync-guild-integration
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) SyncGuildIntegration(ctx context.Context, guildID, integrationID Snowflake, flags ...Flag) (err error) {
@@ -2132,7 +2132,7 @@ func (c *Client) SyncGuildIntegration(ctx context.Context, guildID, integrationI
 }
 
 // updateCurrentUserNickParams ...
-// https://discordapp.com/developers/docs/resources/guild#modify-guild-member-json-params
+// https://discord.com/developers/docs/resources/guild#modify-guild-member-json-params
 type updateCurrentUserNickParams struct {
 	Nick string `json:"nick"` // :CHANGE_NICKNAME
 }
@@ -2145,7 +2145,7 @@ type nickNameResponse struct {
 // with the nickname on success. Fires a Guild Member Update Gateway event.
 //  Method                  PATCH
 //  Endpoint                /guilds/{guild.id}/members/@me/nick
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#modify-current-user-nick
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#modify-current-user-nick
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) SetCurrentUserNick(ctx context.Context, id Snowflake, nick string, flags ...Flag) (newNick string, err error) {
@@ -2171,7 +2171,7 @@ func (c *Client) SetCurrentUserNick(ctx context.Context, id Snowflake, nick stri
 // GetGuildEmbed [REST] Returns the guild embed object. Requires the 'MANAGE_GUILD' permission.
 //  Method                  GET
 //  Endpoint                /guilds/{guild.id}/embed
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#get-guild-embed
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#get-guild-embed
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) GetGuildEmbed(ctx context.Context, guildID Snowflake, flags ...Flag) (embed *GuildEmbed, err error) {
@@ -2190,7 +2190,7 @@ func (c *Client) GetGuildEmbed(ctx context.Context, guildID Snowflake, flags ...
 // modified. Requires the 'MANAGE_GUILD' permission. Returns the updated guild embed object.
 //  Method                  PATCH
 //  Endpoint                /guilds/{guild.id}/embed
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#modify-guild-embed
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#modify-guild-embed
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) UpdateGuildEmbed(ctx context.Context, guildID Snowflake, flags ...Flag) (builder *updateGuildEmbedBuilder) {
@@ -2213,7 +2213,7 @@ func (c *Client) UpdateGuildEmbed(ctx context.Context, guildID Snowflake, flags 
 // Requires the 'MANAGE_GUILD' permission.
 //  Method                  GET
 //  Endpoint                /guilds/{guild.id}/vanity-url
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#get-guild-vanity-url
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#get-guild-vanity-url
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) GetGuildVanityURL(ctx context.Context, guildID Snowflake, flags ...Flag) (ret *PartialInvite, err error) {
@@ -2234,7 +2234,7 @@ func (c *Client) GetGuildVanityURL(ctx context.Context, guildID Snowflake, flags
 //
 //////////////////////////////////////////////////////
 
-// updateGuildBuilder https://discordapp.com/developers/docs/resources/guild#modify-guild-json-params
+// updateGuildBuilder https://discord.com/developers/docs/resources/guild#modify-guild-json-params
 //generate-rest-params: name:string, region:string, verification_level:int, default_message_notifications:DefaultMessageNotificationLvl, explicit_content_filter:ExplicitContentFilterLvl, afk_channel_id:Snowflake, afk_timeout:int, icon:string, owner_id:Snowflake, splash:string, system_channel_id:Snowflake,
 //generate-rest-basic-execute: guild:*Guild,
 type updateGuildBuilder struct {
@@ -2248,7 +2248,7 @@ type updateGuildEmbedBuilder struct {
 }
 
 // updateGuildMemberBuilder ...
-// https://discordapp.com/developers/docs/resources/guild#modify-guild-member-json-params
+// https://discord.com/developers/docs/resources/guild#modify-guild-member-json-params
 //generate-rest-params: nick:string, roles:[]Snowflake, mute:bool, deaf:bool, channel_id:Snowflake,
 //generate-rest-basic-execute: err:error,
 type updateGuildMemberBuilder struct {

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -3,7 +3,7 @@ package endpoint
 
 // endpoints/paths
 const (
-	discordAPI   = "https://discordapp.com/api"
+	discordAPI   = "https://discord.com/api"
 	auditlogs    = "/audit-logs"
 	channels     = "/channels"
 	messages     = "/messages"

--- a/internal/gateway/client.go
+++ b/internal/gateway/client.go
@@ -516,7 +516,7 @@ func (c *client) receiver(ctx context.Context) {
 				switch closeErr.code {
 				case 4014:
 					// Disconnected: Either the channel was deleted or you were kicked. Should not reconnect.
-					// https://discordapp.com/developers/docs/topics/opcodes-and-status-codes#voice-voice-close-event-codes
+					// https://discord.com/developers/docs/topics/opcodes-and-status-codes#voice-voice-close-event-codes
 					c.log.Debug(c.getLogPrefix(), "discord sent a 4014 websocket code and the bot will now disconnect")
 					_ = c.Disconnect()
 					close(c.receiveChan) // notify client

--- a/internal/gateway/packets.go
+++ b/internal/gateway/packets.go
@@ -59,7 +59,7 @@ type VoiceReady struct {
 	Port  int      `json:"port"`
 	Modes []string `json:"modes"`
 
-	// From: https://discordapp.com/developers/docs/topics/voice-connections#establishing-a-voice-websocket-connection
+	// From: https://discord.com/developers/docs/topics/voice-connections#establishing-a-voice-websocket-connection
 	// `heartbeat_interval` here is an erroneous field and should be ignored.
 	// The correct heartbeat_interval value comes from the Hello payload.
 

--- a/internal/gateway/sharding.go
+++ b/internal/gateway/sharding.go
@@ -67,7 +67,7 @@ func ConfigureShardConfig(ctx context.Context, client GatewayBotGetter, conf *Sh
 }
 
 // enableGuildSubscriptions if both typing event and presence event are to be ignore, we can disable GuildSubscription
-// https://discordapp.com/developers/docs/topics/gateway#guild-subscriptions
+// https://discord.com/developers/docs/topics/gateway#guild-subscriptions
 func enableGuildSubscriptions(ignore []string) (updatedIgnores []string, ok bool) {
 	requires := []string{
 		event.TypingStart, event.PresenceUpdate,

--- a/internal/gateway/voiceclient.go
+++ b/internal/gateway/voiceclient.go
@@ -149,7 +149,7 @@ func (c *VoiceClient) onResumed(v interface{}) (err error) {
 }
 
 func (c *VoiceClient) onHeartbeatRequest(v interface{}) error {
-	// https://discordapp.com/developers/docs/topics/gateway#heartbeating
+	// https://discord.com/developers/docs/topics/gateway#heartbeating
 	return c.emit(cmd.VoiceHeartbeat, nil)
 }
 
@@ -299,7 +299,7 @@ func (c *VoiceClient) sendVoiceHelloPacket() {
 }
 
 func sendVoiceIdentityPacket(m *VoiceClient) (err error) {
-	// https://discordapp.com/developers/docs/topics/gateway#identify
+	// https://discord.com/developers/docs/topics/gateway#identify
 	err = m.emit(cmd.VoiceIdentify, &voiceIdentify{
 		GuildID:   m.conf.GuildID,
 		UserID:    m.conf.UserID,

--- a/internal/httd/README.md
+++ b/internal/httd/README.md
@@ -26,7 +26,7 @@ Visually the following fields wrapped in ~~ should be ignored. The `X-RateLimit-
 ```
 
 ## Rate Limit and endpoint relationships
-Linking a given endpoint to a bucket is a serious hassle as Discord does not return the bucket hash on each response. This is really unfortunate as we can't establish relationships between buckets and endpoints before Discord decides to randomly send them (...). This also regards the HTTP methods, even tho the documentation states otherwise. [The docs are useless for insight on this matter.](https://github.com/discordapp/discord-api-docs/issues/1135)
+Linking a given endpoint to a bucket is a serious hassle as Discord does not return the bucket hash on each response. This is really unfortunate as we can't establish relationships between buckets and endpoints before Discord decides to randomly send them (...). This also regards the HTTP methods, even tho the documentation states otherwise. [The docs are useless for insight on this matter.](https://github.com/discord/discord-api-docs/issues/1135)
 
 To tackle this, every hashed endpoint is assumed to have its own bucket. To hash an endpoint before it can be linked to a bucket, the snowflakes, except major snowflakes, must be replaced with the string `{id}`.  Major snowflakes are the first snowflakes in any endpoint with the prefixes ["/channels", "/guilds", "/webhooks"].
 

--- a/internal/httd/client.go
+++ b/internal/httd/client.go
@@ -17,7 +17,7 @@ import (
 
 // defaults and string format's for Discord interaction
 const (
-	BaseURL = "https://discordapp.com/api"
+	BaseURL = "https://discord.com/api"
 
 	RegexpSnowflakes     = `([0-9]+)`
 	RegexpURLSnowflakes  = `\/` + RegexpSnowflakes + `\/?`

--- a/internal/ratelimit/ratelimits.go
+++ b/internal/ratelimit/ratelimits.go
@@ -18,7 +18,7 @@ func (a *b) Test() bool {
 
 // endpoints/paths
 const (
-	discordAPI   = "https://discordapp.com/api"
+	discordAPI   = "https://discord.com/api"
 	auditlogs    = "/audit-logs"
 	channels     = "/channels"
 	messages     = "/messages"

--- a/invite.go
+++ b/invite.go
@@ -15,7 +15,7 @@ import (
 type PartialInvite = Invite
 
 // Invite Represents a code that when used, adds a user to a guild.
-// https://discordapp.com/developers/docs/resources/invite#invite-object
+// https://discord.com/developers/docs/resources/invite#invite-object
 // Reviewed: 2018-06-10
 type Invite struct {
 	Lockable `json:"-"`
@@ -96,7 +96,7 @@ func (i *Invite) CopyOverTo(other interface{}) (err error) {
 }
 
 // InviteMetadata Object
-// https://discordapp.com/developers/docs/resources/invite#invite-metadata-object
+// https://discord.com/developers/docs/resources/invite#invite-metadata-object
 // Reviewed: 2018-06-10
 type InviteMetadata struct {
 	Lockable `json:"-"`
@@ -181,7 +181,7 @@ var _ URLQueryStringer = (*GetInviteParams)(nil)
 // GetInvite [REST] Returns an invite object for the given code.
 //  Method                  GET
 //  Endpoint                /invites/{invite.code}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/invite#get-invite
+//  Discord documentation   https://discord.com/developers/docs/resources/invite#get-invite
 //  Reviewed                2018-06-10
 //  Comment                 -
 //  withMemberCount: whether or not the invite should contain the approximate number of members
@@ -202,7 +202,7 @@ func (c *Client) GetInvite(ctx context.Context, inviteCode string, params URLQue
 // DeleteInvite [REST] Delete an invite. Requires the MANAGE_CHANNELS permission. Returns an invite object on success.
 //  Method                  DELETE
 //  Endpoint                /invites/{invite.code}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/invite#delete-invite
+//  Discord documentation   https://discord.com/developers/docs/resources/invite#delete-invite
 //  Reviewed                2018-06-10
 //  Comment                 -
 func (c *Client) DeleteInvite(ctx context.Context, inviteCode string, flags ...Flag) (deleted *Invite, err error) {

--- a/message.go
+++ b/message.go
@@ -168,7 +168,7 @@ func (m *Message) DiscordURL() (string, error) {
 	}
 
 	return fmt.Sprintf(
-		"https://discordapp.com/channels/%d/%d/%d",
+		"https://discord.com/channels/%d/%d/%d",
 		m.GuildID, m.ChannelID, m.ID,
 	), nil
 }

--- a/message.go
+++ b/message.go
@@ -77,7 +77,7 @@ func NewMessage() *Message {
 //	ChannelID Snowflake `json:"channel_id"`
 //}
 
-// MessageActivity https://discordapp.com/developers/docs/resources/channel#message-object-message-activity-structure
+// MessageActivity https://discord.com/developers/docs/resources/channel#message-object-message-activity-structure
 type MessageActivity struct {
 	Type    int    `json:"type"`
 	PartyID string `json:"party_id"`
@@ -96,7 +96,7 @@ type MessageReference struct {
 	GuildID   Snowflake `json:"guild_id"`
 }
 
-// MessageApplication https://discordapp.com/developers/docs/resources/channel#message-object-message-application-structure
+// MessageApplication https://discord.com/developers/docs/resources/channel#message-object-message-application-structure
 type MessageApplication struct {
 	ID          Snowflake `json:"id"`
 	CoverImage  string    `json:"cover_image"`
@@ -105,7 +105,7 @@ type MessageApplication struct {
 	Name        string    `json:"name"`
 }
 
-// Message https://discordapp.com/developers/docs/resources/channel#message-object-message-structure
+// Message https://discord.com/developers/docs/resources/channel#message-object-message-structure
 type Message struct {
 	Lockable         `json:"-"`
 	ID               Snowflake          `json:"id"`
@@ -155,7 +155,7 @@ func (m *Message) String() string {
 // DiscordURL returns the Discord link to the message. This can be used to jump
 // directly to a message from within the client.
 //
-// Example: https://discordapp.com/channels/319567980491046913/644376487331495967/646925626523254795
+// Example: https://discord.com/channels/319567980491046913/644376487331495967/646925626523254795
 func (m *Message) DiscordURL() (string, error) {
 	if m.ID.IsZero() {
 		return "", errors.New("missing message ID")
@@ -383,7 +383,7 @@ func (m *Message) Unreact(ctx context.Context, s Session, emoji interface{}, fla
 //
 //////////////////////////////////////////////////////
 
-// GetChannelMessagesParams https://discordapp.com/developers/docs/resources/channel#get-channel-messages-query-string-params
+// GetChannelMessagesParams https://discord.com/developers/docs/resources/channel#get-channel-messages-query-string-params
 // TODO: ensure limits
 type GetMessagesParams struct {
 	Around Snowflake `urlparam:"around,omitempty"`
@@ -418,7 +418,7 @@ var _ URLQueryStringer = (*GetMessagesParams)(nil)
 // (since they cannot read the message history). Returns an array of message objects on success.
 //  Method                  GET
 //  Endpoint                /channels/{channel.id}/messages
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#get-channel-messages
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#get-channel-messages
 //  Reviewed                2018-06-10
 //  Comment                 The before, after, and around keys are mutually exclusive, only one may
 //                          be passed at a time. see ReqGetChannelMessagesParams.
@@ -553,7 +553,7 @@ func (c *Client) GetMessages(ctx context.Context, channelID Snowflake, filter *G
 // Returns a message object on success.
 //  Method                  GET
 //  Endpoint                /channels/{channel.id}/messages/{message.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#get-channel-message
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#get-channel-message
 //  Reviewed                2018-06-10
 //  Comment                 -
 func (c *Client) GetMessage(ctx context.Context, channelID, messageID Snowflake, flags ...Flag) (message *Message, err error) {
@@ -697,7 +697,7 @@ func (f *CreateMessageFileParams) write(i int, mp *multipart.Writer) error {
 // The maximum request size when sending a message is 8MB.
 //  Method                  POST
 //  Endpoint                /channels/{channel.id}/messages
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#create-message
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#create-message
 //  Reviewed                2018-06-10
 //  Comment                 Before using this endpoint, you must connect to and identify with a gateway at least once.
 func (c *Client) CreateMessage(ctx context.Context, channelID Snowflake, params *CreateMessageParams, flags ...Flag) (ret *Message, err error) {
@@ -738,7 +738,7 @@ func (c *Client) CreateMessage(ctx context.Context, channelID Snowflake, params 
 // current user. Returns a message object. Fires a Message Update Gateway event.
 //  Method                  PATCH
 //  Endpoint                /channels/{channel.id}/messages/{message.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#edit-message
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#edit-message
 //  Reviewed                2018-06-10
 //  Comment                 All parameters to this endpoint are optional.
 // TODO: verify embed is working
@@ -765,7 +765,7 @@ func (c *Client) UpdateMessage(ctx context.Context, chanID, msgID Snowflake, fla
 // on success. Fires a Message Delete Gateway event.
 //  Method                  DELETE
 //  Endpoint                /channels/{channel.id}/messages/{message.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#delete-message
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#delete-message
 //  Reviewed                2018-06-10
 //  Comment                 -
 func (c *Client) DeleteMessage(ctx context.Context, channelID, msgID Snowflake, flags ...Flag) (err error) {
@@ -789,7 +789,7 @@ func (c *Client) DeleteMessage(ctx context.Context, channelID, msgID Snowflake, 
 	return err
 }
 
-// DeleteMessagesParams https://discordapp.com/developers/docs/resources/channel#bulk-delete-messages-json-params
+// DeleteMessagesParams https://discord.com/developers/docs/resources/channel#bulk-delete-messages-json-params
 type DeleteMessagesParams struct {
 	Messages []Snowflake `json:"messages"`
 	m        sync.RWMutex
@@ -846,7 +846,7 @@ func (p *DeleteMessagesParams) AddMessage(msg *Message) (err error) {
 // will only be counted once.
 //  Method                  POST
 //  Endpoint                /channels/{channel.id}/messages/bulk-delete
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#delete-message
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#delete-message
 //  Reviewed                2018-06-10
 //  Comment                 This endpoint will not delete messages older than 2 weeks, and will fail if any message
 //                          provided is older than that.
@@ -878,7 +878,7 @@ func (c *Client) DeleteMessages(ctx context.Context, chanID Snowflake, params *D
 // on success. Fires a Typing Start Gateway event.
 //  Method                  POST
 //  Endpoint                /channels/{channel.id}/typing
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#trigger-typing-indicator
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#trigger-typing-indicator
 //  Reviewed                2018-06-10
 //  Comment                 -
 func (c *Client) TriggerTypingIndicator(ctx context.Context, channelID Snowflake, flags ...Flag) (err error) {
@@ -896,7 +896,7 @@ func (c *Client) TriggerTypingIndicator(ctx context.Context, channelID Snowflake
 // GetPinnedMessages [REST] Returns all pinned messages in the channel as an array of message objects.
 //  Method                  GET
 //  Endpoint                /channels/{channel.id}/pins
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#get-pinned-messages
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#get-pinned-messages
 //  Reviewed                2018-06-10
 //  Comment                 -
 func (c *Client) GetPinnedMessages(ctx context.Context, channelID Snowflake, flags ...Flag) (ret []*Message, err error) {
@@ -921,7 +921,7 @@ func (c *Client) PinMessage(ctx context.Context, message *Message, flags ...Flag
 // Returns a 204 empty response on success.
 //  Method                  PUT
 //  Endpoint                /channels/{channel.id}/pins/{message.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#add-pinned-channel-message
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#add-pinned-channel-message
 //  Reviewed                2018-06-10
 //  Comment                 -
 func (c *Client) PinMessageID(ctx context.Context, channelID, messageID Snowflake, flags ...Flag) (err error) {
@@ -945,7 +945,7 @@ func (c *Client) UnpinMessage(ctx context.Context, message *Message, flags ...Fl
 // Returns a 204 empty response on success. Returns a 204 empty response on success.
 //  Method                  DELETE
 //  Endpoint                /channels/{channel.id}/pins/{message.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#delete-pinned-channel-message
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#delete-pinned-channel-message
 //  Reviewed                2018-06-10
 //  Comment                 -
 func (c *Client) UnpinMessageID(ctx context.Context, channelID, messageID Snowflake, flags ...Flag) (err error) {
@@ -988,7 +988,7 @@ func (c *Client) SetMsgEmbed(ctx context.Context, chanID, msgID Snowflake, embed
 //////////////////////////////////////////////////////
 
 // updateMessageBuilder, params here
-//  https://discordapp.com/developers/docs/resources/channel#edit-message-json-params
+//  https://discord.com/developers/docs/resources/channel#edit-message-json-params
 //generate-rest-params: content:string, embed:*Embed,
 //generate-rest-basic-execute: message:*Message,
 type updateMessageBuilder struct {

--- a/reaction.go
+++ b/reaction.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Reaction ...
-// https://discordapp.com/developers/docs/resources/channel#reaction-object
+// https://discord.com/developers/docs/resources/channel#reaction-object
 type Reaction struct {
 	Lockable `json:"-"`
 
@@ -64,7 +64,7 @@ func (r *Reaction) CopyOverTo(other interface{}) (err error) {
 // response on success. The maximum request size when sending a message is 8MB.
 //  Method                  PUT
 //  Endpoint                /channels/{channel.id}/messages/{message.id}/reactions/{emoji}/@me
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#create-reaction
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#create-reaction
 //  Reviewed                2019-01-30
 //  Comment                 emoji either unicode (string) or *Emoji with an snowflake Snowflake if it's custom
 func (c *Client) CreateReaction(ctx context.Context, channelID, messageID Snowflake, emoji interface{}, flags ...Flag) (err error) {
@@ -106,7 +106,7 @@ func (c *Client) CreateReaction(ctx context.Context, channelID, messageID Snowfl
 // Returns a 204 empty response on success.
 //  Method                  DELETE
 //  Endpoint                /channels/{channel.id}/messages/{message.id}/reactions/{emoji}/@me
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#delete-own-reaction
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#delete-own-reaction
 //  Reviewed                2019-01-28
 //  Comment                 emoji either unicode (string) or *Emoji with an snowflake Snowflake if it's custom
 func (c *Client) DeleteOwnReaction(ctx context.Context, channelID, messageID Snowflake, emoji interface{}, flags ...Flag) (err error) {
@@ -147,7 +147,7 @@ func (c *Client) DeleteOwnReaction(ctx context.Context, channelID, messageID Sno
 // to be present on the current user. Returns a 204 empty response on success.
 //  Method                  DELETE
 //  Endpoint                /channels/{channel.id}/messages/{message.id}/reactions/{emoji}/@me
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#delete-user-reaction
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#delete-user-reaction
 //  Reviewed                2019-01-28
 //  Comment                 emoji either unicode (string) or *Emoji with an snowflake Snowflake if it's custom
 func (c *Client) DeleteUserReaction(ctx context.Context, channelID, messageID, userID Snowflake, emoji interface{}, flags ...Flag) (err error) {
@@ -184,7 +184,7 @@ func (c *Client) DeleteUserReaction(ctx context.Context, channelID, messageID, u
 	return err
 }
 
-// GetReactionURLParams https://discordapp.com/developers/docs/resources/channel#get-reactions-query-string-params
+// GetReactionURLParams https://discord.com/developers/docs/resources/channel#get-reactions-query-string-params
 type GetReactionURLParams struct {
 	Before Snowflake `urlparam:"before,omitempty"` // get users before this user Snowflake
 	After  Snowflake `urlparam:"after,omitempty"`  // get users after this user Snowflake
@@ -196,7 +196,7 @@ var _ URLQueryStringer = (*GetReactionURLParams)(nil)
 // GetReaction [REST] Get a list of users that reacted with this emoji. Returns an array of user objects on success.
 //  Method                  GET
 //  Endpoint                /channels/{channel.id}/messages/{message.id}/reactions/{emoji}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#get-reactions
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#get-reactions
 //  Reviewed                2019-01-28
 //  Comment                 emoji either unicode (string) or *Emoji with an snowflake Snowflake if it's custom
 func (c *Client) GetReaction(ctx context.Context, channelID, messageID Snowflake, emoji interface{}, params URLQueryStringer, flags ...Flag) (ret []*User, err error) {
@@ -243,7 +243,7 @@ func (c *Client) GetReaction(ctx context.Context, channelID, messageID Snowflake
 // permission to be present on the current user.
 //  Method                  DELETE
 //  Endpoint                /channels/{channel.id}/messages/{message.id}/reactions
-//  Discord documentation   https://discordapp.com/developers/docs/resources/channel#delete-all-reactions
+//  Discord documentation   https://discord.com/developers/docs/resources/channel#delete-all-reactions
 //  Reviewed                2019-01-28
 //  Comment                 emoji either unicode (string) or *Emoji with an snowflake Snowflake if it's custom
 func (c *Client) DeleteAllReactions(ctx context.Context, channelID, messageID Snowflake, flags ...Flag) (err error) {

--- a/rest.go
+++ b/rest.go
@@ -425,7 +425,7 @@ type basicBuilder struct {
 // properly establish a connection using the cached version of the URL.
 //  Method                  GET
 //  Endpoint                /gateway
-//  Discord documentation   https://discordapp.com/developers/docs/topics/gateway#get-gateway
+//  Discord documentation   https://discord.com/developers/docs/topics/gateway#get-gateway
 //  Reviewed                2018-10-12
 //  Comment                 This endpoint does not require authentication.
 func (c *Client) GetGateway(ctx context.Context) (gateway *gateway.Gateway, err error) {
@@ -448,7 +448,7 @@ func (c *Client) GetGateway(ctx context.Context) (gateway *gateway.Gateway, err 
 // changes as the bot joins/leaves guilds.
 //  Method                  GET
 //  Endpoint                /gateway/bot
-//  Discord documentation   https://discordapp.com/developers/docs/topics/gateway#get-gateway-bot
+//  Discord documentation   https://discord.com/developers/docs/topics/gateway#get-gateway-bot
 //  Reviewed                2018-10-12
 //  Comment                 This endpoint requires authentication using a valid bot token.
 func (c *Client) GetGatewayBot(ctx context.Context) (gateway *gateway.GatewayBot, err error) {

--- a/role.go
+++ b/role.go
@@ -47,7 +47,7 @@ func NewRole() *Role {
 	return &Role{}
 }
 
-// Role https://discordapp.com/developers/docs/topics/permissions#role-object
+// Role https://discord.com/developers/docs/topics/permissions#role-object
 type Role struct {
 	Lockable `json:"-"`
 
@@ -151,7 +151,7 @@ func (r *Role) deleteFromDiscord(ctx context.Context, s Session, flags ...Flag) 
 //////////////////////////////////////////////////////
 
 // CreateGuildRoleParams ...
-// https://discordapp.com/developers/docs/resources/guild#create-guild-role-json-params
+// https://discord.com/developers/docs/resources/guild#create-guild-role-json-params
 type CreateGuildRoleParams struct {
 	Name        string `json:"name,omitempty"`
 	Permissions uint64 `json:"permissions,omitempty"`
@@ -167,7 +167,7 @@ type CreateGuildRoleParams struct {
 // Returns the new role object on success. Fires a Guild Role Create Gateway event.
 //  Method                  POST
 //  Endpoint                /guilds/{guild.id}/roles
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#create-guild-role
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#create-guild-role
 //  Reviewed                2018-08-18
 //  Comment                 All JSON params are optional.
 func (c *Client) CreateGuildRole(ctx context.Context, id Snowflake, params *CreateGuildRoleParams, flags ...Flag) (ret *Role, err error) {
@@ -195,7 +195,7 @@ func (c *Client) CreateGuildRole(ctx context.Context, id Snowflake, params *Crea
 // Returns the updated role on success. Fires a Guild Role Update Gateway event.
 //  Method                  PATCH
 //  Endpoint                /guilds/{guild.id}/roles/{role.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#modify-guild-role
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#modify-guild-role
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) UpdateGuildRole(ctx context.Context, guildID, roleID Snowflake, flags ...Flag) (builder *updateGuildRoleBuilder) {
@@ -224,7 +224,7 @@ func (c *Client) UpdateGuildRole(ctx context.Context, guildID, roleID Snowflake,
 // Returns a 204 empty response on success. Fires a Guild Role Delete Gateway event.
 //  Method                  DELETE
 //  Endpoint                /guilds/{guild.id}/roles/{role.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#delete-guild-role
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#delete-guild-role
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) DeleteGuildRole(ctx context.Context, guildID, roleID Snowflake, flags ...Flag) (err error) {
@@ -242,7 +242,7 @@ func (c *Client) DeleteGuildRole(ctx context.Context, guildID, roleID Snowflake,
 // GetGuildRoles [REST] Returns a list of role objects for the guild.
 //  Method                  GET
 //  Endpoint                /guilds/{guild.id}/roles
-//  Discord documentation   https://discordapp.com/developers/docs/resources/guild#get-guild-roles
+//  Discord documentation   https://discord.com/developers/docs/resources/guild#get-guild-roles
 //  Reviewed                2018-08-18
 //  Comment                 -
 func (c *Client) GetGuildRoles(ctx context.Context, guildID Snowflake, flags ...Flag) (ret []*Role, err error) {

--- a/session.go
+++ b/session.go
@@ -186,7 +186,7 @@ type RESTChannel interface {
 	// DeleteChannelPermission Delete a channel permission overwrite for a user or role in a channel. Only usable
 	// for guild channels. Requires the 'MANAGE_ROLES' permission. Returns a 204 empty response on success. For more
 	// information about permissions,
-	// see permissions: https://discordapp.com/developers/docs/topics/permissions#permissions
+	// see permissions: https://discord.com/developers/docs/topics/permissions#permissions
 	DeleteChannelPermission(ctx context.Context, channelID, overwriteID Snowflake, flags ...Flag) (err error)
 
 	// AddDMParticipant Adds a recipient to a Group DM using their access token. Returns a 204 empty response

--- a/struct.go
+++ b/struct.go
@@ -88,7 +88,7 @@ type guilder interface {
 }
 
 // Mentioner can be implemented by any type that is mentionable.
-// https://discordapp.com/developers/docs/reference#message-formatting-formats
+// https://discord.com/developers/docs/reference#message-formatting-formats
 type Mentioner interface {
 	Mention() string
 }
@@ -170,7 +170,7 @@ func (t Time) String() string {
 // levels
 
 // ExplicitContentFilterLvl ...
-// https://discordapp.com/developers/docs/resources/guild#guild-object-explicit-content-filter-level
+// https://discord.com/developers/docs/resources/guild#guild-object-explicit-content-filter-level
 type ExplicitContentFilterLvl uint
 
 // Explicit content filter levels
@@ -196,7 +196,7 @@ func (ecfl *ExplicitContentFilterLvl) AllMembers() bool {
 }
 
 // MFALvl ...
-// https://discordapp.com/developers/docs/resources/guild#guild-object-mfa-level
+// https://discord.com/developers/docs/resources/guild#guild-object-mfa-level
 type MFALvl uint
 
 // Different MFA levels
@@ -216,7 +216,7 @@ func (mfal *MFALvl) Elevated() bool {
 }
 
 // VerificationLvl ...
-// https://discordapp.com/developers/docs/resources/guild#guild-object-verification-level
+// https://discord.com/developers/docs/resources/guild#guild-object-verification-level
 type VerificationLvl uint
 
 // the different verification levels
@@ -254,7 +254,7 @@ func (vl *VerificationLvl) VeryHigh() bool {
 }
 
 // DefaultMessageNotificationLvl ...
-// https://discordapp.com/developers/docs/resources/guild#guild-object-default-message-notification-level
+// https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level
 type DefaultMessageNotificationLvl uint
 
 // different notification levels on new messages

--- a/user.go
+++ b/user.go
@@ -216,7 +216,7 @@ func (a *ActivityTimestamp) CopyOverTo(other interface{}) (err error) {
 // ##
 // ######################
 
-// activityTypes https://discordapp.com/developers/docs/topics/gateway#activity-object-activity-types
+// activityTypes https://discord.com/developers/docs/topics/gateway#activity-object-activity-types
 type acitivityType = int // TODO-v0.15: remove = sign, make uint
 
 const (
@@ -227,7 +227,7 @@ const (
 	ActivityTypeCustom
 )
 
-// activityFlag https://discordapp.com/developers/docs/topics/gateway#activity-object-activity-flags
+// activityFlag https://discord.com/developers/docs/topics/gateway#activity-object-activity-flags
 type activityFlag = int // TODO-v0.15: remove = sign, make uint
 
 // flags for the Activity object to signify the type of action taken place
@@ -247,7 +247,7 @@ func NewActivity() (activity *Activity) {
 	}
 }
 
-// Activity https://discordapp.com/developers/docs/topics/gateway#activity-object-activity-structure
+// Activity https://discord.com/developers/docs/topics/gateway#activity-object-activity-structure
 type Activity struct {
 	Lockable `json:"-"`
 
@@ -755,7 +755,7 @@ var _ URLQueryStringer = (*GetCurrentUserGuildsParams)(nil)
 // with an email.
 //  Method                  GET
 //  Endpoint                /users/@me
-//  Discord documentation   https://discordapp.com/developers/docs/resources/user#get-current-user
+//  Discord documentation   https://discord.com/developers/docs/resources/user#get-current-user
 //  Reviewed                2019-02-23
 //  Comment                 -
 func (c *Client) GetCurrentUser(ctx context.Context, flags ...Flag) (user *User, err error) {
@@ -777,7 +777,7 @@ func (c *Client) GetCurrentUser(ctx context.Context, flags ...Flag) (user *User,
 // GetUser [REST] Returns a user object for a given user Snowflake.
 //  Method                  GET
 //  Endpoint                /users/{user.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/user#get-user
+//  Discord documentation   https://discord.com/developers/docs/resources/user#get-user
 //  Reviewed                2018-06-10
 //  Comment                 -
 func (c *Client) GetUser(ctx context.Context, id Snowflake, flags ...Flag) (*User, error) {
@@ -796,7 +796,7 @@ func (c *Client) GetUser(ctx context.Context, id Snowflake, flags ...Flag) (*Use
 // UpdateCurrentUser [REST] Modify the requester's user account settings. Returns a user object on success.
 //  Method                  PATCH
 //  Endpoint                /users/@me
-//  Discord documentation   https://discordapp.com/developers/docs/resources/user#modify-current-user
+//  Discord documentation   https://discord.com/developers/docs/resources/user#modify-current-user
 //  Reviewed                2019-02-18
 //  Comment                 -
 func (c *Client) UpdateCurrentUser(ctx context.Context, flags ...Flag) (builder *updateCurrentUserBuilder) {
@@ -818,7 +818,7 @@ func (c *Client) UpdateCurrentUser(ctx context.Context, flags ...Flag) (builder 
 // Requires the guilds OAuth2 scope.
 //  Method                  GET
 //  Endpoint                /users/@me/guilds
-//  Discord documentation   https://discordapp.com/developers/docs/resources/user#get-current-user-guilds
+//  Discord documentation   https://discord.com/developers/docs/resources/user#get-current-user-guilds
 //  Reviewed                2019-02-18
 //  Comment                 This endpoint. returns 100 guilds by default, which is the maximum number of
 //                          guilds a non-bot user can join. Therefore, pagination is not needed for
@@ -847,7 +847,7 @@ func (c *Client) GetCurrentUserGuilds(ctx context.Context, params *GetCurrentUse
 // LeaveGuild [REST] Leave a guild. Returns a 204 empty response on success.
 //  Method                  DELETE
 //  Endpoint                /users/@me/guilds/{guild.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/user#leave-guild
+//  Discord documentation   https://discord.com/developers/docs/resources/user#leave-guild
 //  Reviewed                2019-02-18
 //  Comment                 -
 func (c *Client) LeaveGuild(ctx context.Context, id Snowflake, flags ...Flag) (err error) {
@@ -871,10 +871,10 @@ func (c *Client) LeaveGuild(ctx context.Context, id Snowflake, flags ...Flag) (e
 // GetUserDMs [REST] Returns a list of DM channel objects.
 //  Method                  GET
 //  Endpoint                /users/@me/channels
-//  Discord documentation   https://discordapp.com/developers/docs/resources/user#get-user-dms
+//  Discord documentation   https://discord.com/developers/docs/resources/user#get-user-dms
 //  Reviewed                2019-02-19
 //  Comment                 Apparently Discord removed support for this in 2016 and updated their docs 2 years after..
-//							https://github.com/discordapp/discord-api-docs/issues/184
+//							https://github.com/discord/discord-api-docs/issues/184
 //							For now I'll just leave this here, until I can do a cache lookup. Making this cache
 //							dependent.
 // Deprecated: Needs cache checking to get the actual list of channels
@@ -908,7 +908,7 @@ type BodyUserCreateDM struct {
 // CreateDM [REST] Create a new DM channel with a user. Returns a DM channel object.
 //  Method                  POST
 //  Endpoint                /users/@me/channels
-//  Discord documentation   https://discordapp.com/developers/docs/resources/user#create-dm
+//  Discord documentation   https://discord.com/developers/docs/resources/user#create-dm
 //  Reviewed                2019-02-23
 //  Comment                 -
 func (c *Client) CreateDM(ctx context.Context, recipientID Snowflake, flags ...Flag) (ret *Channel, err error) {
@@ -928,7 +928,7 @@ func (c *Client) CreateDM(ctx context.Context, recipientID Snowflake, flags ...F
 }
 
 // CreateGroupDMParams required JSON params for func CreateGroupDM
-// https://discordapp.com/developers/docs/resources/user#create-group-dm
+// https://discord.com/developers/docs/resources/user#create-group-dm
 type CreateGroupDMParams struct {
 	// AccessTokens access tokens of users that have granted your app the gdm.join scope
 	AccessTokens []string `json:"access_tokens"`
@@ -942,7 +942,7 @@ type CreateGroupDMParams struct {
 // endpoint will not be shown in the Discord Client
 //  Method                  POST
 //  Endpoint                /users/@me/channels
-//  Discord documentation   https://discordapp.com/developers/docs/resources/user#create-group-dm
+//  Discord documentation   https://discord.com/developers/docs/resources/user#create-group-dm
 //  Reviewed                2019-02-19
 //  Comment                 -
 func (c *Client) CreateGroupDM(ctx context.Context, params *CreateGroupDMParams, flags ...Flag) (ret *Channel, err error) {
@@ -965,7 +965,7 @@ func (c *Client) CreateGroupDM(ctx context.Context, params *CreateGroupDMParams,
 // GetUserConnections [REST] Returns a list of connection objects. Requires the connections OAuth2 scope.
 //  Method                  GET
 //  Endpoint                /users/@me/connections
-//  Discord documentation   https://discordapp.com/developers/docs/resources/user#get-user-connections
+//  Discord documentation   https://discord.com/developers/docs/resources/user#get-user-connections
 //  Reviewed                2019-02-19
 //  Comment                 -
 func (c *Client) GetUserConnections(ctx context.Context, flags ...Flag) (connections []*UserConnection, err error) {

--- a/utils.go
+++ b/utils.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ShardID calculate the shard id for a given guild.
-// https://discordapp.com/developers/docs/topics/gateway#sharding-sharding-formula
+// https://discord.com/developers/docs/topics/gateway#sharding-sharding-formula
 func ShardID(guildID Snowflake, nrOfShards uint) uint {
 	return gateway.GetShardForGuildID(guildID, nrOfShards)
 }
@@ -76,7 +76,7 @@ func ValidateHandlerInputs(inputs ...interface{}) (err error) {
 	return nil
 }
 
-// https://discordapp.com/developers/docs/resources/user#avatar-data
+// https://discord.com/developers/docs/resources/user#avatar-data
 func validAvatarPrefix(avatar string) (valid bool) {
 	if avatar == "" {
 		return false
@@ -105,7 +105,7 @@ func validAvatarPrefix(avatar string) (valid bool) {
 }
 
 // ValidateUsername uses Discords rule-set to verify user-names and nicknames
-// https://discordapp.com/developers/docs/resources/user#usernames-and-nicknames
+// https://discord.com/developers/docs/resources/user#usernames-and-nicknames
 //
 // Note that not all the rules are listed in the docs:
 //  There are other rules and restrictions not shared here for the sake of spam and abuse mitigation, but the

--- a/voice.go
+++ b/voice.go
@@ -9,7 +9,7 @@ import (
 )
 
 // VoiceState Voice State structure
-// https://discordapp.com/developers/docs/resources/voice#voice-state-object
+// https://discord.com/developers/docs/resources/voice#voice-state-object
 // reviewed 2018-09-29
 type VoiceState struct {
 	Lockable `json:"-"`
@@ -94,7 +94,7 @@ func (v *VoiceState) CopyOverTo(other interface{}) (err error) {
 }
 
 // VoiceRegion voice region structure
-// https://discordapp.com/developers/docs/resources/voice#voice-region
+// https://discord.com/developers/docs/resources/voice#voice-region
 type VoiceRegion struct {
 	Lockable `json:"-"`
 
@@ -169,7 +169,7 @@ func (v *VoiceRegion) CopyOverTo(other interface{}) (err error) {
 // GetVoiceRegionsBuilder [REST] Returns an array of voice region objects that can be used when creating servers.
 //  Method                  GET
 //  Endpoint                /voice/regions
-//  Discord documentation   https://discordapp.com/developers/docs/resources/voice#list-voice-regions
+//  Discord documentation   https://discord.com/developers/docs/resources/voice#list-voice-regions
 //  Reviewed                2018-08-21
 //  Comment                 -
 func (c *Client) GetVoiceRegions(ctx context.Context, flags ...Flag) (regions []*VoiceRegion, err error) {

--- a/voiceconnection.go
+++ b/voiceconnection.go
@@ -449,7 +449,7 @@ type voiceSpeakingData struct {
 }
 
 func (v *voiceImpl) opusSendLoop() {
-	// https://discordapp.com/developers/docs/topics/voice-connections#encrypting-and-sending-voice
+	// https://discord.com/developers/docs/topics/voice-connections#encrypting-and-sending-voice
 	header := make([]byte, 12)
 	header[0] = 0x80
 	header[1] = 0x78

--- a/webhook.go
+++ b/webhook.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Webhook Used to represent a webhook
-// https://discordapp.com/developers/docs/resources/webhook#webhook-object
+// https://discord.com/developers/docs/resources/webhook#webhook-object
 type Webhook struct {
 	Lockable `json:"-"`
 
@@ -68,7 +68,7 @@ func (w *Webhook) CopyOverTo(other interface{}) (err error) {
 //////////////////////////////////////////////////////
 
 // CreateWebhookParams json params for the create webhook rest request avatar string
-// https://discordapp.com/developers/docs/resources/user#avatar-data
+// https://discord.com/developers/docs/resources/user#avatar-data
 type CreateWebhookParams struct {
 	Name   string `json:"name"`   // name of the webhook (2-32 characters)
 	Avatar string `json:"avatar"` // avatar data uri scheme, image for the default webhook avatar
@@ -91,7 +91,7 @@ func (c *CreateWebhookParams) FindErrors() error {
 // Returns a webhook object on success.
 //  Method                  POST
 //  Endpoint                /channels/{channel.id}/webhooks
-//  Discord documentation   https://discordapp.com/developers/docs/resources/webhook#create-webhook
+//  Discord documentation   https://discord.com/developers/docs/resources/webhook#create-webhook
 //  Reviewed                2018-08-14
 //  Comment                 -
 func (c *Client) CreateWebhook(ctx context.Context, channelID Snowflake, params *CreateWebhookParams, flags ...Flag) (ret *Webhook, err error) {
@@ -120,7 +120,7 @@ func (c *Client) CreateWebhook(ctx context.Context, channelID Snowflake, params 
 // GetChannelWebhooks [REST] Returns a list of channel webhook objects. Requires the 'MANAGE_WEBHOOKS' permission.
 //  Method                  POST
 //  Endpoint                /channels/{channel.id}/webhooks
-//  Discord documentation   https://discordapp.com/developers/docs/resources/webhook#get-channel-webhooks
+//  Discord documentation   https://discord.com/developers/docs/resources/webhook#get-channel-webhooks
 //  Reviewed                2018-08-14
 //  Comment                 -
 func (c *Client) GetChannelWebhooks(ctx context.Context, channelID Snowflake, flags ...Flag) (ret []*Webhook, err error) {
@@ -139,7 +139,7 @@ func (c *Client) GetChannelWebhooks(ctx context.Context, channelID Snowflake, fl
 // GetGuildWebhooks [REST] Returns a list of guild webhook objects. Requires the 'MANAGE_WEBHOOKS' permission.
 //  Method                  GET
 //  Endpoint                /guilds/{guild.id}/webhooks
-//  Discord documentation   https://discordapp.com/developers/docs/resources/webhook#get-guild-webhooks
+//  Discord documentation   https://discord.com/developers/docs/resources/webhook#get-guild-webhooks
 //  Reviewed                2018-08-14
 //  Comment                 -
 func (c *Client) GetGuildWebhooks(ctx context.Context, guildID Snowflake, flags ...Flag) (ret []*Webhook, err error) {
@@ -158,7 +158,7 @@ func (c *Client) GetGuildWebhooks(ctx context.Context, guildID Snowflake, flags 
 // GetWebhook [REST] Returns the new webhook object for the given id.
 //  Method                  GET
 //  Endpoint                /webhooks/{webhook.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/webhook#get-webhook
+//  Discord documentation   https://discord.com/developers/docs/resources/webhook#get-webhook
 //  Reviewed                2018-08-14
 //  Comment                 -
 func (c *Client) GetWebhook(ctx context.Context, id Snowflake, flags ...Flag) (ret *Webhook, err error) {
@@ -177,7 +177,7 @@ func (c *Client) GetWebhook(ctx context.Context, id Snowflake, flags ...Flag) (r
 // returns no user in the webhook object.
 //  Method                  GET
 //  Endpoint                /webhooks/{webhook.id}/{webhook.token}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/webhook#get-webhook-with-token
+//  Discord documentation   https://discord.com/developers/docs/resources/webhook#get-webhook-with-token
 //  Reviewed                2018-08-14
 //  Comment                 -
 func (c *Client) GetWebhookWithToken(ctx context.Context, id Snowflake, token string, flags ...Flag) (ret *Webhook, err error) {
@@ -196,7 +196,7 @@ func (c *Client) GetWebhookWithToken(ctx context.Context, id Snowflake, token st
 // Returns the updated webhook object on success.
 //  Method                  PATCH
 //  Endpoint                /webhooks/{webhook.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/webhook#modify-webhook
+//  Discord documentation   https://discord.com/developers/docs/resources/webhook#modify-webhook
 //  Reviewed                2018-08-14
 //  Comment                 All parameters to this endpoint.
 func (c *Client) UpdateWebhook(ctx context.Context, id Snowflake, flags ...Flag) (builder *updateWebhookBuilder) {
@@ -220,7 +220,7 @@ func (c *Client) UpdateWebhook(ctx context.Context, id Snowflake, flags ...Flag)
 // does _not_ accept a channel_id parameter in the body, and does not return a user in the webhook object.
 //  Method                  PATCH
 //  Endpoint                /webhooks/{webhook.id}/{webhook.token}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/webhook#modify-webhook-with-token
+//  Discord documentation   https://discord.com/developers/docs/resources/webhook#modify-webhook-with-token
 //  Reviewed                2018-08-14
 //  Comment                 All parameters to this endpoint. are optional.
 func (c *Client) UpdateWebhookWithToken(ctx context.Context, id Snowflake, token string, flags ...Flag) (builder *updateWebhookBuilder) {
@@ -244,7 +244,7 @@ func (c *Client) UpdateWebhookWithToken(ctx context.Context, id Snowflake, token
 // DeleteWebhook [REST] Delete a webhook permanently. User must be owner. Returns a 204 NO CONTENT response on success.
 //  Method                  DELETE
 //  Endpoint                /webhooks/{webhook.id}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/webhook#delete-webhook
+//  Discord documentation   https://discord.com/developers/docs/resources/webhook#delete-webhook
 //  Reviewed                2018-08-14
 //  Comment                 -
 func (c *Client) DeleteWebhook(ctx context.Context, id Snowflake, flags ...Flag) (err error) {
@@ -254,7 +254,7 @@ func (c *Client) DeleteWebhook(ctx context.Context, id Snowflake, flags ...Flag)
 // DeleteWebhookWithToken [REST] Same as DeleteWebhook, except this call does not require authentication.
 //  Method                  DELETE
 //  Endpoint                /webhooks/{webhook.id}/{webhook.token}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/webhook#delete-webhook-with-token
+//  Discord documentation   https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token
 //  Reviewed                2018-08-14
 //  Comment                 -
 func (c *Client) DeleteWebhookWithToken(ctx context.Context, id Snowflake, token string, flags ...Flag) (err error) {
@@ -306,7 +306,7 @@ var _ URLQueryStringer = (*execWebhookParams)(nil)
 // ExecuteWebhook [REST] Trigger a webhook in Discord.
 //  Method                  POST
 //  Endpoint                /webhooks/{webhook.id}/{webhook.token}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/webhook#execute-webhook
+//  Discord documentation   https://discord.com/developers/docs/resources/webhook#execute-webhook
 //  Reviewed                2018-08-14
 //  Comment                 This endpoint. supports both JSON and form data bodies. It does require
 //                          multipart/form-data requests instead of the normal JSON request type when
@@ -352,7 +352,7 @@ func (c *Client) ExecuteWebhook(ctx context.Context, params *ExecuteWebhookParam
 // ExecuteSlackWebhook [REST] Trigger a webhook in Discord from the Slack app.
 //  Method                  POST
 //  Endpoint                /webhooks/{webhook.id}/{webhook.token}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/webhook#execute-slackcompatible-webhook
+//  Discord documentation   https://discord.com/developers/docs/resources/webhook#execute-slackcompatible-webhook
 //  Reviewed                2018-08-14
 //  Comment                 Refer to Slack's documentation for more information. We do not support Slack's channel,
 //                          icon_emoji, mrkdwn, or mrkdwn_in properties.
@@ -363,7 +363,7 @@ func (c *Client) ExecuteSlackWebhook(ctx context.Context, params *ExecuteWebhook
 // ExecuteGitHubWebhook [REST] Trigger a webhook in Discord from the GitHub app.
 //  Method                  POST
 //  Endpoint                /webhooks/{webhook.id}/{webhook.token}
-//  Discord documentation   https://discordapp.com/developers/docs/resources/webhook#execute-githubcompatible-webhook
+//  Discord documentation   https://discord.com/developers/docs/resources/webhook#execute-githubcompatible-webhook
 //  Reviewed                2018-08-14
 //  Comment                 Add a new webhook to your GitHub repo (in the repo's settings), and use this endpoint.
 //                          as the "Payload URL." You can choose what events your Discord channel receives by
@@ -379,7 +379,7 @@ func (c *Client) ExecuteGitHubWebhook(ctx context.Context, params *ExecuteWebhoo
 //
 //////////////////////////////////////////////////////
 
-// UpdateWebhookParams https://discordapp.com/developers/docs/resources/webhook#modify-webhook-json-params
+// UpdateWebhookParams https://discord.com/developers/docs/resources/webhook#modify-webhook-json-params
 // Allows changing the name of the webhook, avatar and moving it to another channel. It also allows to resetting the
 // avatar by providing a nil to SetAvatar.
 //


### PR DESCRIPTION
# Description

The discord domain has changed from `discordapp.com` -> `discord.com` and this PR reflects documentation updates including the official documentation from [discord.com/developers/docs](https://discord.com/developers/docs/) as well as GitHub references.

The PR also updates the endpoints from `discordapp.com/api` to `discord.com/api`. It doesn't however remove some references to discordapp where there has been no migration such as `cdn.discordapp.com` as no DNS record exists for `cdn.discord.com`. It also does not touch the test cases which an email ending `@discordapp.com`.
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Benchmarks
If this PR requires benchmarks (say it is an very dependent component or takes a lot of resources/use, use pprof if you need to) then the benchmarks are provided before and after such that we can make logical decisions.
Note that if you add a benchmark and find your solution to run slower, the code might still be valuable so your results are welcomed anyways!
If no benchmarks are needed, feel free to delete til paragraph.

# Checklist:

- [x] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
