### PR TITLE
Add undocumented fields to the Invite struct.

### DIFF
--- a/invite.go
+++ b/invite.go
@@ -29,12 +29,34 @@ type Invite struct {
 	// Channel the channel this invite is for
 	Channel *PartialChannel `json:"channel"`
 
+	// Inviter the user that created the invite
+	Inviter *User `json:"inviter"`
+
+	// CreatedAt the time at which the invite was created
+	CreatedAt Time `json:"created_at"`
+
+	// MaxAge how long the invite is valid for (in seconds)
+	MaxAge int `json:"max_age"`
+
+	// MaxUses the maximum number of times the invite can be used
+	MaxUses int `json:"max_uses"`
+
+	// Temporary whether or not the invite is temporary (invited users will be kicked on disconnect unless they're assigned a role)
+	Temporary bool `json:"temporary"`
+
+	// Uses how many times the invite has been used (always will be 0)
+	Uses int `json:"uses"`
+
+	Revoked bool `json:"revoked"`
+	Unique  bool `json:"unique"`
+
 	// ApproximatePresenceCount approximate count of online members
 	ApproximatePresenceCount int `json:"approximate_presence_count,omitempty"`
 
 	// ApproximatePresenceCount approximate count of total members
 	ApproximateMemberCount int `json:"approximate_member_count,omitempty"`
 }
+
 
 var _ Copier = (*Invite)(nil)
 var _ DeepCopier = (*Invite)(nil)


### PR DESCRIPTION
# Description

The Invite struct, that is being returned from invite-related functions, has also some undocumented fields, that would be added. 

Some fields are described here:
https://discord.com/developers/docs/topics/gateway#invite-create-invite-create-event-fields

Some (like Revoked and Unique) aren't described anywhere.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
