### PR TITLE
Fix data race in between Connect and Emit when checking the shardManager

### DIFF
--- a/client.go
+++ b/client.go
@@ -397,6 +397,11 @@ func (c *Client) Connect(ctx context.Context) (err error) {
 	// only works for socketing
 	//
 	// also verifies that the correct credentials were supplied
+
+	// Avoid races during connection setup
+	c.Lock()
+	defer c.Unlock()
+
 	var me *User
 	if me, err = c.GetCurrentUser(ctx); err != nil {
 		return err
@@ -652,6 +657,8 @@ func (c *Client) On(event string, inputs ...interface{}) {
 
 // Emit sends a socket command directly to Discord.
 func (c *Client) Emit(name gatewayCmdName, payload gatewayCmdPayload) (unchandledGuildIDs []Snowflake, err error) {
+	c.RLock()
+	defer c.RUnlock()
 	if c.shardManager == nil {
 		return nil, errors.New("you must connect before you can Emit")
 	}


### PR DESCRIPTION
# Description
Fix a race between client.Connect() and client.Emit() when writing and reading client.shardManager

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
