### PR TITLE
Fix ExecuteWebhook when wait=true

### DIFF
--- a/internal/constant/version.go
+++ b/internal/constant/version.go
@@ -1,3 +1,3 @@
 package constant
 
-const Version = "v0.17.0"
+const Version = "v0.17.1"

--- a/internal/gateway/client.go
+++ b/internal/gateway/client.go
@@ -162,7 +162,7 @@ type client struct {
 	ChannelBuffer uint
 
 	log         logger.Logger
-	logSequence atomic.Uint64
+	logSequence atomic.Uint32 // ARM 32bit causes panic with 64bit
 
 	// behaviours - optional
 	behaviors map[string]*behavior
@@ -254,7 +254,7 @@ func (c *client) getLogPrefix() string {
 	}
 
 	nr := c.logSequence.Add(1)
-	s := "s:" + strconv.FormatUint(nr, 10)
+	s := "s:" + strconv.FormatUint(uint64(nr), 10)
 	shardID := "shard:" + strconv.FormatUint(uint64(c.ShardID), 10)
 
 	// [ws-?, s:0, shard:0]

--- a/internal/gateway/eventclient.go
+++ b/internal/gateway/eventclient.go
@@ -146,7 +146,7 @@ type EvtClient struct {
 	ignoreEvents []string
 
 	sessionID      string
-	sequenceNumber atomic.Uint64
+	sequenceNumber atomic.Uint32
 
 	rdyPool *sync.Pool
 

--- a/internal/gateway/eventclient_test.go
+++ b/internal/gateway/eventclient_test.go
@@ -150,7 +150,7 @@ func TestEvtClient_communication(t *testing.T) {
 		t.Fatal(err)
 	}
 	m.timeoutMultiplier = 0
-	seq := uint64(1)
+	seq := uint32(1)
 
 	// ###############################
 	// RECONNECT
@@ -185,7 +185,7 @@ func TestEvtClient_communication(t *testing.T) {
 	}()
 
 	// mocked websocket server.. ish
-	go func(seq *uint64) {
+	go func(seq *uint32) {
 		for {
 			var data *clientPacket
 			select {

--- a/internal/gateway/packets.go
+++ b/internal/gateway/packets.go
@@ -113,7 +113,7 @@ type evtIdentity struct {
 type evtResume struct {
 	Token      string `json:"token"`
 	SessionID  string `json:"session_id"`
-	SequenceNr uint64 `json:"seq"`
+	SequenceNr uint32 `json:"seq"`
 }
 
 type RequestGuildMembersPayload struct {
@@ -229,7 +229,7 @@ type helloPacket struct {
 type discordPacketJSON struct {
 	Op             opcode.OpCode `json:"op"`
 	Data           []byte        `json:"d"`
-	SequenceNumber uint64        `json:"s"`
+	SequenceNumber uint32        `json:"s"`
 	EventName      string        `json:"t"`
 }
 
@@ -244,7 +244,7 @@ func (p *discordPacketJSON) CopyOverTo(packet *DiscordPacket) {
 type DiscordPacket struct {
 	Op             opcode.OpCode   `json:"op"`
 	Data           json.RawMessage `json:"d"`
-	SequenceNumber uint64          `json:"s,omitempty"`
+	SequenceNumber uint32          `json:"s,omitempty"`
 	EventName      string          `json:"t,omitempty"`
 }
 

--- a/internal/gateway/packets_disgordperf.go
+++ b/internal/gateway/packets_disgordperf.go
@@ -61,14 +61,14 @@ func (p *DiscordPacket) UnmarshalJSON(data []byte) (err error) {
 			val.WriteByte(data[i])
 		}
 		var tmp uint64
-		tmp, err = strconv.ParseUint(val.String(), 10, 64)
+		tmp, err = strconv.ParseUint(val.String(), 10, 32)
 		if err != nil {
 			evt := discordPacketJSON{}
 			err = util.Unmarshal(data, &evt)
 			evt.CopyOverTo(p)
 			return
 		}
-		p.SequenceNumber = tmp
+		p.SequenceNumber = uint32(tmp)
 	}
 
 	// op

--- a/session.go
+++ b/session.go
@@ -451,13 +451,13 @@ type RESTWebhook interface {
 	DeleteWebhookWithToken(ctx context.Context, id Snowflake, token string, flags ...Flag) error
 
 	// ExecuteWebhook Trigger a webhook in Discord.
-	ExecuteWebhook(ctx context.Context, params *ExecuteWebhookParams, wait bool, URLSuffix string, flags ...Flag) error
+	ExecuteWebhook(ctx context.Context, params *ExecuteWebhookParams, wait bool, URLSuffix string, flags ...Flag) (*Message, error)
 
 	// ExecuteSlackWebhook Trigger a webhook in Discord from the Slack app.
-	ExecuteSlackWebhook(ctx context.Context, params *ExecuteWebhookParams, wait bool, flags ...Flag) error
+	ExecuteSlackWebhook(ctx context.Context, params *ExecuteWebhookParams, wait bool, flags ...Flag) (*Message, error)
 
 	// ExecuteGitHubWebhook Trigger a webhook in Discord from the GitHub app.
-	ExecuteGitHubWebhook(ctx context.Context, params *ExecuteWebhookParams, wait bool, flags ...Flag) error
+	ExecuteGitHubWebhook(ctx context.Context, params *ExecuteWebhookParams, wait bool, flags ...Flag) (*Message, error)
 }
 
 // RESTer holds all the sub REST interfaces

--- a/webhook.go
+++ b/webhook.go
@@ -343,6 +343,7 @@ func (c *Client) ExecuteWebhook(ctx context.Context, params *ExecuteWebhookParam
 		Body:        params,
 		ContentType: contentType,
 	}, flags)
+	r.pool = c.pool.message
 	if wait {
 		r.expectsStatusCode = http.StatusOK
 	} else {

--- a/webhook.go
+++ b/webhook.go
@@ -316,16 +316,16 @@ var _ URLQueryStringer = (*execWebhookParams)(nil)
 //  Comment#2               For the webhook embed objects, you can set every field except type (it will be
 //                          rich regardless of if you try to set it), provider, video, and any height, width,
 //                          or proxy_url values for images.
-func (c *Client) ExecuteWebhook(ctx context.Context, params *ExecuteWebhookParams, wait bool, URLSuffix string, flags ...Flag) (err error) {
+func (c *Client) ExecuteWebhook(ctx context.Context, params *ExecuteWebhookParams, wait bool, URLSuffix string, flags ...Flag) (message *Message, err error) {
 	if params == nil {
-		return errors.New("params can not be nil")
+		return nil, errors.New("params can not be nil")
 	}
 
 	if params.WebhookID.IsZero() {
-		return errors.New("webhook id is required")
+		return nil, errors.New("webhook id is required")
 	}
 	if params.Token == "" {
-		return errors.New("webhook token is required")
+		return nil, errors.New("webhook token is required")
 	}
 
 	var contentType string
@@ -343,25 +343,25 @@ func (c *Client) ExecuteWebhook(ctx context.Context, params *ExecuteWebhookParam
 		Body:        params,
 		ContentType: contentType,
 	}, flags)
-	r.pool = c.pool.message
+	// Discord only returns the message when wait=true.
 	if wait {
+		r.pool = c.pool.message
 		r.expectsStatusCode = http.StatusOK
-	} else {
-		r.expectsStatusCode = http.StatusNoContent
+		return getMessage(r.Execute)
 	}
-
+	r.expectsStatusCode = http.StatusNoContent
 	_, err = r.Execute()
-	return err
+	return nil, err
 }
 
 // ExecuteSlackWebhook [REST] Trigger a webhook in Discord from the Slack app.
 //  Method                  POST
 //  Endpoint                /webhooks/{webhook.id}/{webhook.token}
 //  Discord documentation   https://discord.com/developers/docs/resources/webhook#execute-slackcompatible-webhook
-//  Reviewed                2018-08-14
+//  Reviewed                2020-05-21
 //  Comment                 Refer to Slack's documentation for more information. We do not support Slack's channel,
 //                          icon_emoji, mrkdwn, or mrkdwn_in properties.
-func (c *Client) ExecuteSlackWebhook(ctx context.Context, params *ExecuteWebhookParams, wait bool, flags ...Flag) (err error) {
+func (c *Client) ExecuteSlackWebhook(ctx context.Context, params *ExecuteWebhookParams, wait bool, flags ...Flag) (message *Message, err error) {
 	return c.ExecuteWebhook(ctx, params, wait, endpoint.Slack(), flags...)
 }
 
@@ -369,12 +369,12 @@ func (c *Client) ExecuteSlackWebhook(ctx context.Context, params *ExecuteWebhook
 //  Method                  POST
 //  Endpoint                /webhooks/{webhook.id}/{webhook.token}
 //  Discord documentation   https://discord.com/developers/docs/resources/webhook#execute-githubcompatible-webhook
-//  Reviewed                2018-08-14
+//  Reviewed                2020-05-21
 //  Comment                 Add a new webhook to your GitHub repo (in the repo's settings), and use this endpoint.
 //                          as the "Payload URL." You can choose what events your Discord channel receives by
 //                          choosing the "Let me select individual events" option and selecting individual
 //                          events for the new webhook you're configuring.
-func (c *Client) ExecuteGitHubWebhook(ctx context.Context, params *ExecuteWebhookParams, wait bool, flags ...Flag) (err error) {
+func (c *Client) ExecuteGitHubWebhook(ctx context.Context, params *ExecuteWebhookParams, wait bool, flags ...Flag) (message *Message, err error) {
 	return c.ExecuteWebhook(ctx, params, wait, endpoint.GitHub(), flags...)
 }
 

--- a/webhook.go
+++ b/webhook.go
@@ -307,7 +307,7 @@ var _ URLQueryStringer = (*execWebhookParams)(nil)
 //  Method                  POST
 //  Endpoint                /webhooks/{webhook.id}/{webhook.token}
 //  Discord documentation   https://discord.com/developers/docs/resources/webhook#execute-webhook
-//  Reviewed                2018-08-14
+//  Reviewed                2020-05-21
 //  Comment                 This endpoint. supports both JSON and form data bodies. It does require
 //                          multipart/form-data requests instead of the normal JSON request type when
 //                          uploading files. Make sure you set your Content-Type to multipart/form-data if
@@ -343,7 +343,11 @@ func (c *Client) ExecuteWebhook(ctx context.Context, params *ExecuteWebhookParam
 		Body:        params,
 		ContentType: contentType,
 	}, flags)
-	r.expectsStatusCode = http.StatusNoContent // TODO: verify
+	if wait {
+		r.expectsStatusCode = http.StatusOK
+	} else {
+		r.expectsStatusCode = http.StatusNoContent
+	}
 
 	_, err = r.Execute()
 	return err


### PR DESCRIPTION
# Description

This changes ExecuteWebhook to return the posted message when wait=true. Previously it would error out expecting an empty response body.

## Type of change

Please delete options that are not relevant.
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Benchmarks

n/a

# Checklist:

- [x] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
