### PR TITLE
Fix SIGSEGV (issue #298) and hearthbeating in voice

### DIFF
--- a/internal/gateway/voiceclient.go
+++ b/internal/gateway/voiceclient.go
@@ -192,9 +192,8 @@ func (c *VoiceClient) onHello(v interface{}) (err error) {
 	c.heartbeatInterval = interval
 	c.Unlock()
 
-	c.activateHeartbeats <- true
-
 	c.sendVoiceHelloPacket()
+	c.activateHeartbeats <- true
 	return nil
 }
 
@@ -298,6 +297,7 @@ func (c *VoiceClient) internalConnect() (evt interface{}, err error) {
 		c.log.Info(c.getLogPrefix(), "connected")
 	case <-ctx.Done():
 		c.isConnected.Store(false)
+		err = errors.New("context cancelled")
 	case <-time.After(5 * time.Second):
 		c.isConnected.Store(false)
 		err = errors.New("did not receive desired event in time. opcode " + strconv.Itoa(int(opcode.VoiceReady)))


### PR DESCRIPTION
# Description

* Fix SIGSEGV panic in issue #298, function now returns non-nil error:
  "context cancelled"

* Fix opCode 3 sending before opCode 0 in voice
	* this caused "authentication error", which resulted in SIGSEGV

* Add & improve errors and logs in (re)connecting functions


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I ran `go generate`
- [ ] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
