### PR TITLE
Fix error returned when closing VoiceClient

### DIFF
--- a/internal/gateway/client.go
+++ b/internal/gateway/client.go
@@ -510,7 +510,9 @@ func (c *client) receiver(ctx context.Context) {
 		var packet []byte
 		var err error
 		if packet, err = c.conn.Read(ctx); err != nil {
-			c.log.Debug(c.getLogPrefix(), "read error: ", err.Error())
+			if !errors.Is(err, context.Canceled) && ctx.Err() != nil {
+				c.log.Debug(c.getLogPrefix(), "read error: ", err.Error())
+			}
 			reconnect := true
 			var closeErr *CloseErr
 			isCloseErr := errors.As(err, &closeErr)


### PR DESCRIPTION
# Description

Modify nhooyr/websocket Read wrapper to handle disconnect after context being cancelled (https://github.com/nhooyr/websocket/issues/242)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I ran `go generate`
- [ ] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
