### PR TITLE
Fix emoji mention to allow rendering of emoji

### DIFF
--- a/emoji.go
+++ b/emoji.go
@@ -61,7 +61,7 @@ func (e *Emoji) Mention() string {
 		prefix = "a:"
 	}
 
-	return "<" + prefix + e.Name + ":" + e.ID.String() + ">"
+	return "<:" + prefix + e.Name + ":" + e.ID.String() + ">"
 }
 
 func (e *Emoji) LinkToGuild(guildID Snowflake) {


### PR DESCRIPTION
# Description

Mentioning an emoji does not give a string that renders the given emoji in a message. This is due to a missing colon before the emoji's name.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)