### PR TITLE
Add GetPermissions function to Channel struct, refactor other permissions code

### DIFF
--- a/permissions_test.go
+++ b/permissions_test.go
@@ -1,0 +1,56 @@
+package disgord
+
+import (
+	"context"
+	"github.com/andersfylling/disgord/internal/util"
+	"testing"
+)
+
+var fakePermissionsRole = &Role{ID: 10, Permissions: 2048}
+
+type permissionTestingSession struct {
+	getFakeRole bool
+}
+
+func (p *permissionTestingSession) GetGuildRoles(_ context.Context, _ Snowflake, _ ...Flag) ([]*Role, error) {
+	if p.getFakeRole {
+		return []*Role{fakePermissionsRole}, nil
+	}
+	return []*Role{}, nil
+}
+
+func TestChannel_GetPermissions_Overwrite(t *testing.T) {
+	data := []byte(`{"permission_overwrites": [{"allow": 2048, "deny": 0, "id": "1", "type": "member"}]}`)
+	var c Channel
+	if err := util.Unmarshal(data, &c); err != nil {
+		t.Fatal(err)
+	}
+	p, err := c.GetPermissions(context.TODO(), &permissionTestingSession{}, &Member{UserID: 1, Roles: []Snowflake{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p != 2048 {
+		t.Fatal("permissions should be 2048, is", p)
+	}
+}
+
+func TestMember_GetPermissions(t *testing.T) {
+	m := &Member{UserID: 1, Roles: []Snowflake{}}
+	s := &permissionTestingSession{}
+	p, err := m.GetPermissions(context.TODO(), s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p != 0 {
+		t.Fatal("permissions should be 0, is", p)
+	}
+	s.getFakeRole = true
+	m.Roles = append(m.Roles, fakePermissionsRole.ID)
+	p, err = m.GetPermissions(context.TODO(), s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p != 2048 {
+		t.Fatal("permissions should be 2048, is", p)
+	}
+}

--- a/role.go
+++ b/role.go
@@ -247,32 +247,11 @@ func (c *Client) GetGuildRoles(ctx context.Context, guildID Snowflake, flags ...
 
 // GetMemberPermissions populates a uint64 with all the permission flags
 func (c *Client) GetMemberPermissions(ctx context.Context, guildID, userID Snowflake, flags ...Flag) (permissions PermissionBits, err error) {
-	roles, err := c.GetGuildRoles(ctx, guildID, flags...)
-	if err != nil {
-		return 0, err
-	}
-
 	member, err := c.GetMember(ctx, guildID, userID, flags...)
 	if err != nil {
 		return 0, err
 	}
-
-	roleIDs := member.Roles
-	for i := range roles {
-		for j := range roleIDs {
-			if roles[i].ID == roleIDs[j] {
-				permissions |= roles[i].Permissions
-				roleIDs = roleIDs[:j+copy(roleIDs[j:], roleIDs[j+1:])]
-				break
-			}
-		}
-
-		if len(roleIDs) == 0 {
-			break
-		}
-	}
-
-	return permissions, nil
+	return member.GetPermissions(ctx, c, flags...)
 }
 
 //////////////////////////////////////////////////////


### PR DESCRIPTION
# Description

Move GetPermissions code to the member rather than session (since before it was mixed between the 2 which caused GetMember to be called twice if it was ran from the Member struct), add GetPermissions function to channel which takes into consideration channel permission overwrites, remove broken check from GetPermissions function on the member (it checked if the user ID was IsZero and then tried to call GetUser if it was, but if it was zero, that call would fail).

This was done to allow for easy permission checking with channels. This is important since there is the potential to get a temporary Cloudflare ban if you get too many no permission errors with channels. This helps to fix that since it allows us to check for the relevant permissions before sending the message easily.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [X] I ran `go generate` (**there were new files here, but I did not commit them because they do not seem related to this and break the unit tests**)
- [X] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
