### PR TITLE
Fix a bug where code generation seems to be failing based on UserFlag

### DIFF
--- a/generate/interfaces/main.go
+++ b/generate/interfaces/main.go
@@ -306,6 +306,8 @@ func getZeroInit(s string) string {
 		return "time.Unix(0, 0)"
 	case "Timestamp":
 		return "Timestamp(time.Unix(0, 0))"
+	case "UserFlag":
+		return "0"
 	}
 
 	if strings.HasPrefix(s, "&{") {

--- a/iface_reseter_gen.go
+++ b/iface_reseter_gen.go
@@ -88,6 +88,7 @@ func (m *Member) Reset() {
 	m.Nick = ""
 	m.Roles = nil
 	m.JoinedAt = Time{}
+	m.PremiumSince = Time{}
 	m.Deaf = false
 	m.Mute = false
 	m.UserID = 0
@@ -172,6 +173,9 @@ func (u *User) Reset() {
 	u.MFAEnabled = false
 	u.Bot = false
 	u.PremiumType = 0
+	u.Locale = ""
+	u.Flags = 0
+	u.PublicFlags = 0
 	u.overwritten = 0
 }
 

--- a/restbuilders_gen.go
+++ b/restbuilders_gen.go
@@ -32,7 +32,7 @@ func (b *guildAuditLogsBuilder) Set(name string, v interface{}) *guildAuditLogsB
 }
 
 func (b *guildAuditLogsBuilder) SetUserID(userID Snowflake) *guildAuditLogsBuilder {
-	b.r.addPrereq(userID.IsZero(), "UserID can not be 0")
+	b.r.addPrereq(userID.IsZero(), "userID can not be 0")
 	b.r.param("user_id", userID)
 	return b
 }


### PR DESCRIPTION
# Description

This simply defaults UserFlag attributes to 0, causing the generation to complete successfully.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [X] I ran `go generate`
- [X] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
