### PR TITLE
Set the GuildID on the member object when it is fetched

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -794,7 +794,8 @@ func (c *Cache) UpdateMemberAndUser(guildID, userID Snowflake, data json.RawMess
 	if member == nil {
 		newMember = true
 		member = &Member{
-			UserID: userID,
+			GuildID: guildID,
+			UserID:  userID,
 		}
 	}
 

--- a/guild.go
+++ b/guild.go
@@ -1371,7 +1371,12 @@ func (c *Client) GetMember(ctx context.Context, guildID, userID Snowflake, flags
 		return &Member{}
 	}
 
-	return getMember(r.Execute)
+	ret, err = getMember(r.Execute)
+	if err != nil {
+		return
+	}
+	ret.GuildID = guildID
+	return
 }
 
 type getGuildMembersParams struct {

--- a/guild.go
+++ b/guild.go
@@ -1546,6 +1546,10 @@ func (c *Client) AddGuildMember(ctx context.Context, guildID, userID Snowflake, 
 		}
 	}
 
+	if member != nil {
+		member.GuildID = guildID
+	}
+
 	return member, err
 }
 


### PR DESCRIPTION
# Description

When I was writing the GetPermissions function on the client I completely forgot about this caveat, causing it to be broken from the Client struct (sorry - that's my bad, I should've tested that function before I PR'd). This fixes that and also makes it easier to access the guild ID with a member object since it doesn't need to be patched in.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Benchmarks
If this PR requires benchmarks (say it is an very dependent component or takes a lot of resources/use, use pprof if you need to) then the benchmarks are provided before and after such that we can make logical decisions.
Note that if you add a benchmark and find your solution to run slower, the code might still be valuable so your results are welcomed anyways!
If no benchmarks are needed, feel free to delete til paragraph.

# Checklist:

- [X] I ran `go generate`
- [X] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
