### PR TITLE
Fix UpdateMemberAndUser breaking when the guild cache is off

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -53,7 +53,7 @@ func TestCache_ChannelCreate(t *testing.T) {
 
 func TestCache_MemberUpdate_MemberCachingDisabled(t *testing.T) {
 	cache, _ := newCache(&CacheConfig{
-		DisableGuildCaching:      true,
+		DisableGuildCaching: true,
 	})
 	b, err := ioutil.ReadFile("testdata/guild/member1.json")
 	if err != nil {

--- a/cache_test.go
+++ b/cache_test.go
@@ -2,7 +2,10 @@
 
 package disgord
 
-import "testing"
+import (
+	"io/ioutil"
+	"testing"
+)
 
 func TestCache_ChannelCreate(t *testing.T) {
 	t.Run("immutable", func(t *testing.T) {
@@ -46,4 +49,52 @@ func TestCache_ChannelCreate(t *testing.T) {
 			t.Error("channel was not affected by external changes")
 		}
 	})
+}
+
+func TestCache_MemberUpdate_MemberCachingDisabled(t *testing.T) {
+	cache, _ := newCache(&CacheConfig{
+		DisableGuildCaching:      true,
+	})
+	b, err := ioutil.ReadFile("testdata/guild/member1.json")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	cache.UpdateMemberAndUser(0, 0, b)
+	u, err := cache.GetUser(0)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	if u.Username != "test" {
+		t.Fatal("should be test")
+	}
+}
+
+func TestCache_MemberUpdate_MemberCachingEnabled(t *testing.T) {
+	cache, _ := newCache(&CacheConfig{})
+	b, err := ioutil.ReadFile("testdata/guild/member1.json")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	cache.SetGuild(&Guild{Name: "test"})
+	g, err := cache.GetGuild(0)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	if g.Name != "test" {
+		t.Fatal("should be test")
+	}
+	cache.UpdateMemberAndUser(0, 0, b)
+	u, err := cache.GetUser(0)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	if u.Username != "test" {
+		t.Fatal("should be test")
+		return
+	}
 }

--- a/cmd/script/main.go
+++ b/cmd/script/main.go
@@ -5,15 +5,15 @@ import (
 	"os"
 
 	"github.com/andersfylling/disgord"
-	"github.com/sirupsen/logrus"
 	"github.com/andersfylling/disgord/std"
+	"github.com/sirupsen/logrus"
 )
 
 var log = &logrus.Logger{
-	Out: os.Stderr,
+	Out:       os.Stderr,
 	Formatter: new(logrus.TextFormatter),
-	Hooks: make(logrus.LevelHooks),
-	Level: logrus.ErrorLevel,
+	Hooks:     make(logrus.LevelHooks),
+	Level:     logrus.ErrorLevel,
 }
 
 // replyPongToPing is a handler that replies pong to ping messages

--- a/docs/examples/logging-custom/bot.go
+++ b/docs/examples/logging-custom/bot.go
@@ -43,7 +43,6 @@ func (log *LoggerZap) Error(v ...interface{}) {
 	_ = log.instance.Sync()
 }
 
-
 func main() {
 	logConf := zap.NewProductionConfig()
 	logConf.Level.SetLevel(zap.DebugLevel)

--- a/docs/examples/logging-plug-and-play/bot.go
+++ b/docs/examples/logging-plug-and-play/bot.go
@@ -1,17 +1,17 @@
 package main
 
 import (
+	"context"
 	"github.com/andersfylling/disgord"
 	"github.com/sirupsen/logrus"
-	"context"
 	"os"
 )
 
 var log = &logrus.Logger{
-	Out: os.Stderr,
+	Out:       os.Stderr,
 	Formatter: new(logrus.TextFormatter),
-	Hooks: make(logrus.LevelHooks),
-	Level: logrus.DebugLevel,
+	Hooks:     make(logrus.LevelHooks),
+	Level:     logrus.DebugLevel,
 }
 
 func main() {

--- a/testdata/guild/member1.json
+++ b/testdata/guild/member1.json
@@ -1,1 +1,1 @@
-{"user":{},"nick":"NOT API SUPPORT","roles":[],"joined_at":"2015-04-26T06:26:56.936000+00:00","deaf":false,"mute":false}
+{"user":{"username":"test"},"nick":"NOT API SUPPORT","roles":[],"joined_at":"2015-04-26T06:26:56.936000+00:00","deaf":false,"mute":false}


### PR DESCRIPTION
# Description

This is relating to https://github.com/MattIPv4/1.1.1.1-Discord/issues/9. Due to not checking if the guild cache is nil, the bot can crash if it's turned off.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [X] I ran `go generate`
- [X] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
