### PR TITLE
Add Activities to PresenceUpdate

### DIFF
--- a/events.go
+++ b/events.go
@@ -596,10 +596,11 @@ type GuildRoleDelete struct {
 
 // PresenceUpdate user's presence was updated in a guild
 type PresenceUpdate struct {
-	User    *User       `json:"user"`
-	RoleIDs []Snowflake `json:"roles"`
-	Game    *Activity   `json:"game"`
-	GuildID Snowflake   `json:"guild_id"`
+	User       *User       `json:"user"`
+	RoleIDs    []Snowflake `json:"roles"`
+	Game       *Activity   `json:"game"`
+	GuildID    Snowflake   `json:"guild_id"`
+	Activities []*Activity `json:"activities"`
 
 	// Status either "idle", "dnd", "online", or "offline"
 	// TODO: constants somewhere..


### PR DESCRIPTION
# Description

Added Activities to PresenceUpdate struct to bring parity with the data sent by the Discord API, fixes issues where a user with a custom status has their status taking precedence over any game they're playing in the PRESENCE_UPDATE event when using the current `PresenceUpdate.Game` field.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
