### PR TITLE
PermissionBits > PermissionBit, add Contains function to PermissionBit

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -59,10 +59,10 @@ func (a *Attachment) DeepCopy() (copy interface{}) {
 
 // PermissionOverwrite https://discord.com/developers/docs/resources/channel#overwrite-object
 type PermissionOverwrite struct {
-	ID    Snowflake      `json:"id"`    // role or user id
-	Type  string         `json:"type"`  // either `role` or `member`
-	Allow PermissionBits `json:"allow"` // permission bit set
-	Deny  PermissionBits `json:"deny"`  // permission bit set
+	ID    Snowflake     `json:"id"`    // role or user id
+	Type  string        `json:"type"`  // either `role` or `member`
+	Allow PermissionBit `json:"allow"` // permission bit set
+	Deny  PermissionBit `json:"deny"`  // permission bit set
 }
 
 // NewChannel ...
@@ -155,7 +155,7 @@ func (c *Channel) valid() bool {
 }
 
 // GetPermissions is used to get a members permissions in a channel.
-func (c *Channel) GetPermissions(ctx context.Context, s PermissionFetching, member *Member, flags ...Flag) (permissions PermissionBits, err error) {
+func (c *Channel) GetPermissions(ctx context.Context, s PermissionFetching, member *Member, flags ...Flag) (permissions PermissionBit, err error) {
 	// Get the guild permissions.
 	permissions, err = member.GetPermissions(ctx, s, flags...)
 	if err != nil {
@@ -414,9 +414,9 @@ func (c *Client) DeleteChannel(ctx context.Context, channelID Snowflake, flags .
 
 // UpdateChannelPermissionsParams https://discord.com/developers/docs/resources/channel#edit-channel-permissions-json-params
 type UpdateChannelPermissionsParams struct {
-	Allow PermissionBits `json:"allow"` // the bitwise value of all allowed permissions
-	Deny  PermissionBits `json:"deny"`  // the bitwise value of all disallowed permissions
-	Type  string         `json:"type"`  // "member" for a user or "role" for a role
+	Allow PermissionBit `json:"allow"` // the bitwise value of all allowed permissions
+	Deny  PermissionBit `json:"deny"`  // the bitwise value of all disallowed permissions
+	Type  string        `json:"type"`  // "member" for a user or "role" for a role
 }
 
 // EditChannelPermissions [REST] Edit the channel permission overwrites for a user or role in a channel. Only usable

--- a/client.go
+++ b/client.go
@@ -212,7 +212,7 @@ type Client struct {
 	botToken     string
 
 	myID        Snowflake
-	permissions PermissionBits
+	permissions PermissionBit
 
 	// reactor demultiplexer for events
 	dispatcher *dispatcher
@@ -268,7 +268,7 @@ func (c *Client) Pool() *pools {
 // This is useful for creating the bot URL.
 //
 // At the moment, this holds no other effect than aesthetics.
-func (c *Client) AddPermission(permission PermissionBits) (updatedPermissions PermissionBits) {
+func (c *Client) AddPermission(permission PermissionBit) (updatedPermissions PermissionBit) {
 	if permission < 0 {
 		permission = 0
 	}
@@ -278,7 +278,7 @@ func (c *Client) AddPermission(permission PermissionBits) (updatedPermissions Pe
 }
 
 // GetPermissions returns the minimum bot requirements.
-func (c *Client) GetPermissions() (permissions PermissionBits) {
+func (c *Client) GetPermissions() (permissions PermissionBit) {
 	return c.permissions
 }
 

--- a/client.go
+++ b/client.go
@@ -268,7 +268,7 @@ func (c *Client) Pool() *pools {
 // This is useful for creating the bot URL.
 //
 // At the moment, this holds no other effect than aesthetics.
-func (c *Client) AddPermission(permission PermissionBit) (updatedPermissions PermissionBits) {
+func (c *Client) AddPermission(permission PermissionBits) (updatedPermissions PermissionBits) {
 	if permission < 0 {
 		permission = 0
 	}

--- a/generate/interfaces/main.go
+++ b/generate/interfaces/main.go
@@ -289,7 +289,7 @@ func getZeroVal(s string) (result string, success bool) {
 	case "nil":
 		result = s
 		// TODO: find out what the original data type is
-	case "VerificationLvl", "DefaultMessageNotificationLvl", "ExplicitContentFilterLvl", "MFALvl", "Discriminator", "PremiumType", "PermissionBits", "PermissionBit", "activityFlag", "acitivityType":
+	case "VerificationLvl", "DefaultMessageNotificationLvl", "ExplicitContentFilterLvl", "MFALvl", "Discriminator", "PremiumType", "PermissionBits", "activityFlag", "acitivityType":
 		result = "0"
 	}
 

--- a/generate/interfaces/main.go
+++ b/generate/interfaces/main.go
@@ -289,7 +289,7 @@ func getZeroVal(s string) (result string, success bool) {
 	case "nil":
 		result = s
 		// TODO: find out what the original data type is
-	case "VerificationLvl", "DefaultMessageNotificationLvl", "ExplicitContentFilterLvl", "MFALvl", "Discriminator", "PremiumType", "PermissionBits", "activityFlag", "acitivityType":
+	case "VerificationLvl", "DefaultMessageNotificationLvl", "ExplicitContentFilterLvl", "MFALvl", "Discriminator", "PremiumType", "PermissionBit", "activityFlag", "acitivityType":
 		result = "0"
 	}
 

--- a/guild.go
+++ b/guild.go
@@ -22,17 +22,17 @@ import (
 // Source code reference:
 //  https://github.com/bwmarrin/discordgo/blob/8325a6bf6dd6c91ed4040a1617b07287b8fb0eba/structs.go#L854
 
-// PermissionBits is used to define the permission bit(s) which are set.
-type PermissionBits uint64
+// PermissionBit is used to define the permission bit(s) which are set.
+type PermissionBit uint64
 
 // Contains is used to check if the permission bits contains the bits specified.
-func (b PermissionBits) Contains(Bits PermissionBits) bool {
+func (b PermissionBit) Contains(Bits PermissionBit) bool {
 	return (b & Bits) == Bits
 }
 
 // Constants for the different bit offsets of text channel permissions
 const (
-	PermissionReadMessages PermissionBits = 1 << (iota + 10)
+	PermissionReadMessages PermissionBit = 1 << (iota + 10)
 	PermissionSendMessages
 	PermissionSendTTSMessages
 	PermissionManageMessages
@@ -45,18 +45,18 @@ const (
 
 // Constants for the different bit offsets of voice permissions
 const (
-	PermissionVoiceConnect PermissionBits = 1 << (iota + 20)
+	PermissionVoiceConnect PermissionBit = 1 << (iota + 20)
 	PermissionVoiceSpeak
 	PermissionVoiceMuteMembers
 	PermissionVoiceDeafenMembers
 	PermissionVoiceMoveMembers
 	PermissionVoiceUseVAD
-	PermissionVoicePrioritySpeaker PermissionBits = 1 << (iota + 2)
+	PermissionVoicePrioritySpeaker PermissionBit = 1 << (iota + 2)
 )
 
 // Constants for general management.
 const (
-	PermissionChangeNickname PermissionBits = 1 << (iota + 26)
+	PermissionChangeNickname PermissionBit = 1 << (iota + 26)
 	PermissionManageNicknames
 	PermissionManageRoles
 	PermissionManageWebhooks
@@ -65,7 +65,7 @@ const (
 
 // Constants for the different bit offsets of general permissions
 const (
-	PermissionCreateInstantInvite PermissionBits = 1 << iota
+	PermissionCreateInstantInvite PermissionBit = 1 << iota
 	PermissionKickMembers
 	PermissionBanMembers
 	PermissionAdministrator
@@ -186,7 +186,7 @@ type Guild struct {
 	Splash                      string                        `json:"splash"`          //  |?, image hash
 	Owner                       bool                          `json:"owner,omitempty"` // ?|
 	OwnerID                     Snowflake                     `json:"owner_id"`
-	Permissions                 PermissionBits                `json:"permissions,omitempty"` // ?|, permission flags for connected user `/users/@me/guilds`
+	Permissions                 PermissionBit                 `json:"permissions,omitempty"` // ?|, permission flags for connected user `/users/@me/guilds`
 	Region                      string                        `json:"region"`
 	AfkChannelID                Snowflake                     `json:"afk_channel_id"` // |?
 	AfkTimeout                  uint                          `json:"afk_timeout"`
@@ -935,7 +935,7 @@ type PermissionFetching interface {
 }
 
 // GetPermissions populates a uint64 with all the permission flags
-func (m *Member) GetPermissions(ctx context.Context, s PermissionFetching, flags ...Flag) (permissions PermissionBits, err error) {
+func (m *Member) GetPermissions(ctx context.Context, s PermissionFetching, flags ...Flag) (permissions PermissionBit, err error) {
 	roles, err := s.GetGuildRoles(ctx, m.GuildID, flags...)
 	if err != nil {
 		return 0, err
@@ -945,7 +945,7 @@ func (m *Member) GetPermissions(ctx context.Context, s PermissionFetching, flags
 	for i := range roles {
 		for j := range roleIDs {
 			if roles[i].ID == roleIDs[j] {
-				permissions |= (PermissionBits)(roles[i].Permissions)
+				permissions |= (PermissionBit)(roles[i].Permissions)
 				roleIDs = roleIDs[:j+copy(roleIDs[j:], roleIDs[j+1:])]
 				break
 			}

--- a/guild.go
+++ b/guild.go
@@ -22,12 +22,17 @@ import (
 // Source code reference:
 //  https://github.com/bwmarrin/discordgo/blob/8325a6bf6dd6c91ed4040a1617b07287b8fb0eba/structs.go#L854
 
-type PermissionBit = uint64
-type PermissionBits = PermissionBit
+// PermissionBits is used to define the permission bit(s) which are set.
+type PermissionBits uint64
+
+// Has is used to check if the permission bits has the bits specified.
+func (b PermissionBits) Has(Bits PermissionBits) bool {
+	return (b & Bits) == Bits
+}
 
 // Constants for the different bit offsets of text channel permissions
 const (
-	PermissionReadMessages PermissionBit = 1 << (iota + 10)
+	PermissionReadMessages PermissionBits = 1 << (iota + 10)
 	PermissionSendMessages
 	PermissionSendTTSMessages
 	PermissionManageMessages
@@ -40,18 +45,18 @@ const (
 
 // Constants for the different bit offsets of voice permissions
 const (
-	PermissionVoiceConnect PermissionBit = 1 << (iota + 20)
+	PermissionVoiceConnect PermissionBits = 1 << (iota + 20)
 	PermissionVoiceSpeak
 	PermissionVoiceMuteMembers
 	PermissionVoiceDeafenMembers
 	PermissionVoiceMoveMembers
 	PermissionVoiceUseVAD
-	PermissionVoicePrioritySpeaker PermissionBit = 1 << (iota + 2)
+	PermissionVoicePrioritySpeaker PermissionBits = 1 << (iota + 2)
 )
 
 // Constants for general management.
 const (
-	PermissionChangeNickname PermissionBit = 1 << (iota + 26)
+	PermissionChangeNickname PermissionBits = 1 << (iota + 26)
 	PermissionManageNicknames
 	PermissionManageRoles
 	PermissionManageWebhooks
@@ -60,7 +65,7 @@ const (
 
 // Constants for the different bit offsets of general permissions
 const (
-	PermissionCreateInstantInvite PermissionBit = 1 << iota
+	PermissionCreateInstantInvite PermissionBits = 1 << iota
 	PermissionKickMembers
 	PermissionBanMembers
 	PermissionAdministrator
@@ -940,7 +945,7 @@ func (m *Member) GetPermissions(ctx context.Context, s PermissionFetching, flags
 	for i := range roles {
 		for j := range roleIDs {
 			if roles[i].ID == roleIDs[j] {
-				permissions |= roles[i].Permissions
+				permissions |= (PermissionBits)(roles[i].Permissions)
 				roleIDs = roleIDs[:j+copy(roleIDs[j:], roleIDs[j+1:])]
 				break
 			}

--- a/guild.go
+++ b/guild.go
@@ -25,8 +25,8 @@ import (
 // PermissionBits is used to define the permission bit(s) which are set.
 type PermissionBits uint64
 
-// Has is used to check if the permission bits has the bits specified.
-func (b PermissionBits) Has(Bits PermissionBits) bool {
+// Contains is used to check if the permission bits contains the bits specified.
+func (b PermissionBits) Contains(Bits PermissionBits) bool {
 	return (b & Bits) == Bits
 }
 

--- a/guild_test.go
+++ b/guild_test.go
@@ -167,13 +167,13 @@ func TestGuild_DeleteChannel(t *testing.T) {
 func TestPermissionBits(t *testing.T) {
 	// test permission bit checking
 	testBits := PermissionSendMessages | PermissionReadMessages
-	if testBits.Has(PermissionAdministrator) {
+	if testBits.Contains(PermissionAdministrator) {
 		t.Fatal("does not have administrator")
 	}
-	if !testBits.Has(PermissionSendMessages) {
+	if !testBits.Contains(PermissionSendMessages) {
 		t.Fatal("does have send messages")
 	}
-	if !testBits.Has(PermissionReadMessages) {
+	if !testBits.Contains(PermissionReadMessages) {
 		t.Fatal("does have read messages")
 	}
 
@@ -186,7 +186,7 @@ func TestPermissionBits(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !testBits.Has(PermissionReadMessages) {
+	if !testBits.Contains(PermissionReadMessages) {
 		t.Fatal("does have read messages")
 	}
 }

--- a/guild_test.go
+++ b/guild_test.go
@@ -164,7 +164,7 @@ func TestGuild_DeleteChannel(t *testing.T) {
 	}
 }
 
-func TestPermissionBits(t *testing.T) {
+func TestPermissionBit(t *testing.T) {
 	// test permission bit checking
 	testBits := PermissionSendMessages | PermissionReadMessages
 	if testBits.Contains(PermissionAdministrator) {

--- a/guild_test.go
+++ b/guild_test.go
@@ -163,3 +163,16 @@ func TestGuild_DeleteChannel(t *testing.T) {
 		t.Error("no error given when requesting a deleted channel")
 	}
 }
+
+func TestPermissionBits(t *testing.T) {
+	testBits := PermissionSendMessages | PermissionReadMessages
+	if testBits.Has(PermissionAdministrator) {
+		t.Fatal("does not have administrator")
+	}
+	if !testBits.Has(PermissionSendMessages) {
+		t.Fatal("does have send messages")
+	}
+	if !testBits.Has(PermissionReadMessages) {
+		t.Fatal("does have read messages")
+	}
+}

--- a/guild_test.go
+++ b/guild_test.go
@@ -165,12 +165,26 @@ func TestGuild_DeleteChannel(t *testing.T) {
 }
 
 func TestPermissionBits(t *testing.T) {
+	// test permission bit checking
 	testBits := PermissionSendMessages | PermissionReadMessages
 	if testBits.Has(PermissionAdministrator) {
 		t.Fatal("does not have administrator")
 	}
 	if !testBits.Has(PermissionSendMessages) {
 		t.Fatal("does have send messages")
+	}
+	if !testBits.Has(PermissionReadMessages) {
+		t.Fatal("does have read messages")
+	}
+
+	// Test json marshal/unmarshal
+	b, err := json.Marshal(testBits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = json.Unmarshal(b, &testBits)
+	if err != nil {
+		t.Fatal(err)
 	}
 	if !testBits.Has(PermissionReadMessages) {
 		t.Fatal("does have read messages")

--- a/restbuilders_gen.go
+++ b/restbuilders_gen.go
@@ -533,7 +533,7 @@ func (b *updateGuildRoleBuilder) SetName(name string) *updateGuildRoleBuilder {
 	return b
 }
 
-func (b *updateGuildRoleBuilder) SetPermissions(permissions PermissionBits) *updateGuildRoleBuilder {
+func (b *updateGuildRoleBuilder) SetPermissions(permissions PermissionBit) *updateGuildRoleBuilder {
 	b.r.param("permissions", permissions)
 	return b
 }

--- a/role.go
+++ b/role.go
@@ -246,7 +246,7 @@ func (c *Client) GetGuildRoles(ctx context.Context, guildID Snowflake, flags ...
 }
 
 // GetMemberPermissions populates a uint64 with all the permission flags
-func (c *Client) GetMemberPermissions(ctx context.Context, guildID, userID Snowflake, flags ...Flag) (permissions PermissionBits, err error) {
+func (c *Client) GetMemberPermissions(ctx context.Context, guildID, userID Snowflake, flags ...Flag) (permissions PermissionBit, err error) {
 	member, err := c.GetMember(ctx, guildID, userID, flags...)
 	if err != nil {
 		return 0, err
@@ -262,7 +262,7 @@ func (c *Client) GetMemberPermissions(ctx context.Context, guildID, userID Snowf
 
 // updateGuildRoleBuilder ...
 //generate-rest-basic-execute: role:*Role,
-//generate-rest-params: name:string, permissions:PermissionBits, color:uint, hoist:bool, mentionable:bool,
+//generate-rest-params: name:string, permissions:PermissionBit, color:uint, hoist:bool, mentionable:bool,
 type updateGuildRoleBuilder struct {
 	r RESTBuilder
 }

--- a/session.go
+++ b/session.go
@@ -302,7 +302,7 @@ type RESTGuild interface {
 	// GetGuildRoles Returns a list of role objects for the guild.
 	GetGuildRoles(ctx context.Context, guildID Snowflake, flags ...Flag) ([]*Role, error)
 
-	GetMemberPermissions(ctx context.Context, guildID, userID Snowflake, flags ...Flag) (permissions PermissionBits, err error)
+	GetMemberPermissions(ctx context.Context, guildID, userID Snowflake, flags ...Flag) (permissions PermissionBit, err error)
 
 	// CreateGuildRole Create a new role for the guild. Requires the 'MANAGE_ROLES' permission.
 	// Returns the new role object on success. Fires a Guild Role Create Gateway event.
@@ -514,8 +514,8 @@ type Session interface {
 	DeleteFromDiscord(ctx context.Context, obj discordDeleter, flags ...Flag) error
 
 	// AddPermission is to store the permissions required by the bot to function as intended.
-	AddPermission(permission PermissionBits) (updatedPermissions PermissionBits)
-	GetPermissions() (permissions PermissionBits)
+	AddPermission(permission PermissionBit) (updatedPermissions PermissionBit)
+	GetPermissions() (permissions PermissionBit)
 
 	// CreateBotURL
 	InviteURL(ctx context.Context) (url string, err error)

--- a/session.go
+++ b/session.go
@@ -514,7 +514,7 @@ type Session interface {
 	DeleteFromDiscord(ctx context.Context, obj discordDeleter, flags ...Flag) error
 
 	// AddPermission is to store the permissions required by the bot to function as intended.
-	AddPermission(permission PermissionBit) (updatedPermissions PermissionBits)
+	AddPermission(permission PermissionBits) (updatedPermissions PermissionBits)
 	GetPermissions() (permissions PermissionBits)
 
 	// CreateBotURL

--- a/std/msgfilter.go
+++ b/std/msgfilter.go
@@ -37,8 +37,8 @@ type msgFilter struct {
 	botID  disgord.Snowflake
 	prefix string
 
-	permissions       disgord.PermissionBits
-	eitherPermissions disgord.PermissionBits
+	permissions       disgord.PermissionBit
+	eitherPermissions disgord.PermissionBit
 }
 
 // SetPrefix set the prefix attribute which is used in StripPrefix, HasPrefix.
@@ -119,14 +119,14 @@ func (f *msgFilter) HasPermissions(evt interface{}) interface{} {
 
 // SetMinPermissions enforces message authors to have at least the given permission flags
 // for the HasPermissions method to succeed
-func (f *msgFilter) SetMinPermissions(min disgord.PermissionBits) {
+func (f *msgFilter) SetMinPermissions(min disgord.PermissionBit) {
 	f.permissions = min
 }
 
 // SetAltPermissions enforces message authors to have at least one of the given permission flags for the
 // HasPermissions method to succeed
-func (f *msgFilter) SetAltPermissions(bits ...disgord.PermissionBits) {
-	var permissions disgord.PermissionBits
+func (f *msgFilter) SetAltPermissions(bits ...disgord.PermissionBit) {
+	var permissions disgord.PermissionBit
 	for i := range bits {
 		permissions |= bits[i]
 	}


### PR DESCRIPTION
# Description

- Removed `PermissionBit` alias to `PermissionBits` since it serves no purpose and rename `PermissionBits` to `PermissionBit`.
- Add `Contains` function to check if permission bits have the other permission bits specified.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [X] I ran `go generate`
- [X] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
