### PR TITLE
Fix a bug where unneeded/breaking manipulation of the roles array happened

### DIFF
--- a/guild.go
+++ b/guild.go
@@ -941,17 +941,17 @@ func (m *Member) GetPermissions(ctx context.Context, s PermissionFetching, flags
 		return 0, err
 	}
 
-	roleIDs := m.Roles
-	for i := range roles {
-		for j := range roleIDs {
-			if roles[i].ID == roleIDs[j] {
-				permissions |= (PermissionBit)(roles[i].Permissions)
-				roleIDs = roleIDs[:j+copy(roleIDs[j:], roleIDs[j+1:])]
+	unprocessedRoles := len(m.Roles)
+	for _, roleInfo := range roles {
+		for _, roleId := range m.Roles {
+			if roleInfo.ID == roleId {
+				permissions |= (PermissionBit)(roleInfo.Permissions)
+				unprocessedRoles--
 				break
 			}
 		}
 
-		if len(roleIDs) == 0 {
+		if unprocessedRoles == 0 {
 			break
 		}
 	}


### PR DESCRIPTION
# Description

During the member GetPermissions function, some unneeded breaking changes happened to the Roles array, affecting what it contained and causing unneeded reallocation.

## Type of change


- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I ran `go generate`
- [X] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
