### PR TITLE
Add AllowedMentions

### DIFF
--- a/client.go
+++ b/client.go
@@ -785,6 +785,10 @@ func (c *Client) SendMsg(ctx context.Context, channelID Snowflake, data ...inter
 			if s, err = msgToParams(t); err != nil {
 				return nil, err
 			}
+		case AllowedMentions:
+			params.AllowedMentions = &t
+		case *AllowedMentions:
+			params.AllowedMentions = t
 		default:
 			var mentioned bool
 			if mentionable, ok := t.(Mentioner); ok {

--- a/message.go
+++ b/message.go
@@ -571,6 +571,8 @@ type CreateMessageParams struct {
 
 	SpoilerTagContent        bool `json:"-"`
 	SpoilerTagAllAttachments bool `json:"-"`
+
+	AllowedMentions *AllowedMentions `json:"allowed_mentions,omitempty"` // The allowed mentions object for the message.
 }
 
 func (p *CreateMessageParams) prepare() (postBody interface{}, contentType string, err error) {
@@ -631,6 +633,17 @@ func (p *CreateMessageParams) prepare() (postBody interface{}, contentType strin
 	contentType = mp.FormDataContentType()
 
 	return
+}
+
+// AllowedMentions allows finer control over mentions in a message.
+// https://discord.com/developers/docs/resources/channel#allowed-mentions-object for more info.
+type AllowedMentions struct {
+	Parse []string `json:"parse"`
+	// Any values in Parse must be any of `everyone`, `users`, `roles`.
+	// This is purposefully not marked as omitempty as to allow `parse: []` which blocks all mentions.
+
+	Roles []Snowflake `json:"roles,omitempty"`
+	Users []Snowflake `json:"users,omitempty"`
 }
 
 // CreateMessageFileParams contains the information needed to upload a file to Discord, it is part of the
@@ -968,4 +981,10 @@ func (c *Client) SetMsgEmbed(ctx context.Context, chanID, msgID Snowflake, embed
 //generate-rest-basic-execute: message:*Message,
 type updateMessageBuilder struct {
 	r RESTBuilder
+}
+
+// SetAllowedMentions sets the allowed mentions for the updateMessageBuilder then returns the builder to allow chaining.
+func (b *updateMessageBuilder) SetAllowedMentions(mentions *AllowedMentions) *updateMessageBuilder {
+	b.r.param("allowed_mentions", mentions)
+	return b
 }

--- a/message.go
+++ b/message.go
@@ -635,12 +635,11 @@ func (p *CreateMessageParams) prepare() (postBody interface{}, contentType strin
 	return
 }
 
-// AllowedMentions allows finer control over mentions in a message.
+// AllowedMentions allows finer control over mentions in a message, see
 // https://discord.com/developers/docs/resources/channel#allowed-mentions-object for more info.
+// Any strings in the Parse value must be any from ["everyone", "users", "roles"].
 type AllowedMentions struct {
-	Parse []string `json:"parse"`
-	// Any values in Parse must be any of `everyone`, `users`, `roles`.
-	// This is purposefully not marked as omitempty as to allow `parse: []` which blocks all mentions.
+	Parse []string `json:"parse"` // this is purposefully not marked as omitempty as to allow `parse: []` which blocks all mentions.
 
 	Roles []Snowflake `json:"roles,omitempty"`
 	Users []Snowflake `json:"users,omitempty"`


### PR DESCRIPTION
# Description

This PR adds AllowedMentions as described in the discord API docs [here](https://discord.com/developers/docs/resources/channel#allowed-mentions-object). I've added this to Client.SendMsg, CreateMessageParams and updateMessageBuilder (updateMessageBuilder.SetAllowedMentions).
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
