### PR TITLE
Update session interface link in pkg docs to pkg.go.dev

### DIFF
--- a/disgord.go
+++ b/disgord.go
@@ -4,7 +4,7 @@
 //
 // Create a Disgord session to get access to the REST API and socket functionality. In the following example, we listen for new messages and write a "hello" message when our handler function gets fired.
 //
-// Session interface: https://godoc.org/github.com/andersfylling/disgord/#Session
+// Session interface: https://pkg.go.dev/github.com/andersfylling/disgord?tab=doc#Session
 //  discord := disgord.New(&disgord.Config{
 //    BotToken: "my-secret-bot-token",
 //  })


### PR DESCRIPTION
# Description

Updated session interface link in the package links which was pointing to the old go docs site.

## Type of change

- [x] Documentation update

# Checklist:

- [x] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)