### PR TITLE
RoundTripper rate limit implementation

### DIFF
--- a/client.go
+++ b/client.go
@@ -44,7 +44,9 @@ func createClient(conf *Config) (c *Client, err error) {
 	}
 	if conf.HTTPClient == nil {
 		// WARNING: do not set http.Client.Timeout (!)
-		conf.HTTPClient = &http.Client{}
+		conf.HTTPClient = &http.Client{
+			Transport: NewRESTRateLimiter(http.DefaultTransport),
+		}
 	} else if conf.HTTPClient.Timeout > 0 {
 		// https://github.com/nhooyr/websocket/issues/67
 		return nil, errors.New("do not set timeout in the http.Client, use context.Context instead")

--- a/internal/httd/discord/http/ratelimit/hash.go
+++ b/internal/httd/discord/http/ratelimit/hash.go
@@ -1,0 +1,56 @@
+package ratelimit
+
+import (
+	"net/url"
+	"strings"
+)
+
+func MajorRoute(path string) bool {
+	for _, prefix := range []string{"guilds", "channels", "webhooks"} {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func HashURL(method string, u *url.URL) string {
+	matches := regexpURLSnowflakes.FindAllString(u.Path, -1)
+	isMajor := MajorRoute(u.Path)
+	buffer := u.Path
+	for i := range matches {
+		if i == 0 && isMajor {
+			continue
+		}
+
+		buffer = strings.ReplaceAll(buffer, matches[i], "/{id}/")
+	}
+
+	// check for reaction endpoints, convert emoji identifier to {emoji}
+	reactionPrefixMatch := regexpURLReactionPrefix.FindAllString(buffer, -1)
+	if reactionPrefixMatch != nil {
+		if regexpURLReactionEmoji.FindAllString(buffer, -1) != nil {
+			reactionEmojis := regexpURLReactionEmojiSegment.FindAllString(buffer, -1)
+			for i := range reactionEmojis {
+				buffer = strings.ReplaceAll(buffer, reactionEmojis[i], "/reactions/{emoji}")
+			}
+		} else {
+			// corner case for urls with emojis
+			suffix := buffer[len(reactionPrefixMatch[0]):]
+			until := len(suffix)
+			for i, r := range suffix {
+				if r == '/' {
+					until = i
+					break
+				}
+			}
+			newSuffix := "{emoji}" + suffix[until:]
+			buffer = buffer[:len(buffer)-len(suffix)] + newSuffix
+		}
+	}
+
+	if strings.HasSuffix(buffer, "/") {
+		buffer = buffer[:len(buffer)-1]
+	}
+	return method + ":" + buffer
+}

--- a/internal/httd/discord/http/ratelimit/header.go
+++ b/internal/httd/discord/http/ratelimit/header.go
@@ -1,0 +1,78 @@
+package ratelimit
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// http rate limit identifiers
+const (
+	XAuditLogReason         = "X-Audit-Log-Reason"
+	XRateLimitPrecision     = "X-RateLimit-Precision"
+	XRateLimitBucket        = "X-RateLimit-Bucket"
+	XRateLimitLimit         = "X-RateLimit-Limit"
+	XRateLimitRemaining     = "X-RateLimit-Remaining"
+	XRateLimitReset         = "X-RateLimit-Reset"
+	XRateLimitResetAfter    = "X-RateLimit-Reset-After"
+	XRateLimitGlobal        = "X-RateLimit-Global"
+	RateLimitRetryAfter     = "Retry-After"
+)
+
+// HeaderToTime takes the response header from Discord and extracts the
+// timestamp. Useful for detecting time desync between discord and client
+func HeaderToTime(header http.Header) (t time.Time, err error) {
+	// date: Fri, 14 Sep 2018 19:04:24 GMT
+	dateStr := header.Get("date")
+	if dateStr == "" {
+		err = errors.New("missing header field 'date'")
+		return
+	}
+
+	t, err = time.Parse(time.RFC1123, dateStr)
+	return
+}
+
+type RateLimitResponseStructure struct {
+	Message    string `json:"message"`     // A message saying you are being rate limited.
+	RetryAfter int64  `json:"retry_after"` // The number of milliseconds to wait before submitting another request.
+	Global     bool   `json:"global"`      // A value indicating if you are being globally rate limited or not
+}
+
+// NormalizeDiscordHeader overrides header fields with body content and make sure every header field
+// uses milliseconds and not seconds. Regards rate limits only.
+func NormalizeDiscordHeader(statusCode int, header http.Header) http.Header {
+	// don't care about 2 different time delay estimates for the ltBucket reset.
+	// So lets take Retry-After and X-RateLimit-Reset-After to set the reset
+	var delay int64
+	if retryAfter := header.Get(RateLimitRetryAfter); retryAfter != "" {
+		delay, _ = strconv.ParseInt(retryAfter, 10, 64)
+	}
+	if retry := header.Get(XRateLimitResetAfter); delay == 0 && retry != "" {
+		delayF, _ := strconv.ParseFloat(retry, 64)
+		delayF *= 1000 // seconds => milliseconds
+		delay = int64(delayF)
+	}
+
+	// convert Reset to store milliseconds and not seconds
+	// if there is no content, we create a Reset unix using the delay
+	if reset := header.Get(XRateLimitReset); reset != "" {
+		epoch, _ := strconv.ParseFloat(reset, 64)
+		epoch *= 1000 // seconds => milliseconds
+		header.Set(XRateLimitReset, strconv.FormatInt(int64(epoch), 10))
+	} else if delay > 0 {
+		timestamp, err := HeaderToTime(header)
+		if err != nil {
+			// does add an delay, but there is no reason
+			// to go insane if timestamp could not be handled
+			timestamp = time.Now()
+		}
+
+		reset := timestamp.Add(time.Duration(delay) * time.Millisecond)
+		ms := reset.UnixNano() / int64(time.Millisecond)
+		header.Set(XRateLimitReset, strconv.FormatInt(ms, 10))
+	}
+
+	return header
+}

--- a/internal/httd/discord/http/ratelimit/passing_game.go
+++ b/internal/httd/discord/http/ratelimit/passing_game.go
@@ -1,0 +1,59 @@
+package ratelimit
+
+import (
+	"context"
+	"sync"
+
+	"go.uber.org/atomic"
+)
+
+// YOU MUST INSTANTIATE homeChan!
+type passingGame struct {
+	homeChan chan *ball
+	once sync.Once
+	done atomic.Bool
+	queue []*player
+	sync.Mutex
+}
+
+func (p *passingGame) add(player *player) {
+	p.Lock()
+	p.queue = append(p.queue, player)
+	p.Unlock()
+
+	p.once.Do(func() {
+		p.homeChan <- &ball{p.homeChan}
+	})
+}
+
+func (p *passingGame) run(ctx context.Context) {
+	if !p.done.CAS(false, true) {
+		return
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-p.homeChan:
+
+		}
+	}
+}
+
+type player struct {
+	c chan<- *ball
+	ctx context.Context
+}
+
+func (p *player) skip() bool {
+	return p.ctx.Err() != nil
+}
+
+type ball struct {
+	home chan *ball
+}
+
+func (b *ball) next() {
+	b.home <- b
+}

--- a/internal/httd/discord/http/ratelimit/queue_cancelation.go
+++ b/internal/httd/discord/http/ratelimit/queue_cancelation.go
@@ -1,0 +1,110 @@
+package ratelimit
+
+import (
+	"context"
+	"sync"
+
+	"go.uber.org/atomic"
+)
+
+func deadContext(ctx context.Context) bool {
+	return ctx.Err() != nil || ctx.Done() == nil
+}
+
+type DoneChan chan interface{}
+
+type queueItem struct {
+	ctx context.Context
+	notify chan (chan interface{})
+}
+
+type queueWithCancellation struct {
+	mu sync.Mutex
+	items []*queueItem
+	change chan int
+	dead atomic.Bool
+}
+
+func (queue *queueWithCancellation) insert(item *queueItem) {
+	queue.mu.Lock()
+	if queue.dead.Load() {
+		queue.mu.Unlock()
+		close(item.notify)
+		return
+	}
+	defer func() {
+		queue.mu.Unlock()
+		queue.change <- 1
+	}()
+
+	if cap(queue.items) == len(queue.items) {
+		length := len(queue.items)
+		tmp := queue.items
+		queue.items = make([]*queueItem, length, length*2)
+		copy(queue.items, tmp)
+	}
+	queue.items = append(queue.items, item)
+}
+
+func (queue *queueWithCancellation) close() {
+	queue.dead.Store(true)
+	close(queue.change)
+}
+
+func (queue *queueWithCancellation) watch() {
+	var debt uint
+	var lastChan chan interface{}
+
+	popBack := func() *queueItem {
+		queue.mu.Lock()
+		data := queue.items[len(queue.items) - 1]
+		queue.items = queue.items[:len(queue.items) - 1]
+		queue.mu.Unlock()
+
+		return data
+	}
+
+	popHandle := func() bool {
+		data := popBack()
+		if deadContext(data.ctx) {
+			return false
+		}
+
+		// close(lastChan) // nop
+		lastChan = make(chan interface{})
+		data.notify <- lastChan
+		return true
+	}
+
+	reactOnNew := true
+	for {
+		select {
+		case _, open := <-queue.change:
+			// assume every change is just a increment of one
+			if !open {
+				queue.mu.Lock()
+				for i := 0; i < len(queue.items); i++ {
+					close(queue.items[i].notify)
+				}
+				queue.mu.Unlock()
+				break
+			}
+
+			if reactOnNew {
+				if popHandle() {
+					reactOnNew = false
+				}
+			} else {
+				debt++
+			}
+		case <-lastChan:
+			if debt == 0 {
+				lastChan = make(chan interface{})
+				reactOnNew = true
+			} else {
+				popHandle()
+				debt--
+			}
+		}
+	}
+}

--- a/internal/httd/discord/http/ratelimit/ratelimit.go
+++ b/internal/httd/discord/http/ratelimit/ratelimit.go
@@ -1,0 +1,7 @@
+package ratelimit
+
+// DiscordRateLimitCompliant is a way to test that the injected RoundTripper implementation support discord rate limits.
+// TODO: is there a way to use a predefined request to verify this instead?
+type DiscordRateLimitCompliant interface {
+	DiscordRateLimitCompliant()
+}

--- a/internal/httd/discord/http/ratelimit/round_tripper.go
+++ b/internal/httd/discord/http/ratelimit/round_tripper.go
@@ -1,0 +1,67 @@
+package ratelimit
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+)
+
+const DiscordAPIURLPrefix = "https://discord.com/api/v"
+
+type RateLimit struct {
+	Original http.RoundTripper
+	queue queueWithCancellation
+}
+
+var _ http.RoundTripper = (*RateLimit)(nil)
+var _ DiscordRateLimitCompliant = (*RateLimit)(nil)
+
+func (r *RateLimit) DiscordRateLimitCompliant() {}
+
+func (r *RateLimit) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	if !r.isDiscordAPIRequest(req) {
+		return r.Original.RoundTrip(req)
+	}
+
+	return r.rateLimit(req, func() (*http.Response, error) {
+		return r.Original.RoundTrip(req)
+	})
+}
+
+func (r *RateLimit) isDiscordAPIRequest(req *http.Request) bool {
+	return strings.HasPrefix(req.URL.String(), DiscordAPIURLPrefix)
+}
+
+func (r *RateLimit) rateLimit(req *http.Request, cb func() (*http.Response, error)) (*http.Response, error) {
+	ctx := req.Context()
+
+
+	wait := make(chan (chan interface{}))
+	r.queue.insert(&queueItem{
+		ctx:    ctx,
+		notify: wait,
+	})
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case done, open := <-wait:
+		defer func() {
+			if open && done != nil {
+				close(done)
+			}
+		}()
+		if !open {
+			return nil, errors.New("rate limit access chanel closed")
+		}
+
+		resp, err := cb()
+		if err != nil {
+			return nil, err
+		}
+		resp.Header = NormalizeDiscordHeader(resp.StatusCode, resp.Header)
+
+		// TODO: update bucket info
+
+		return resp, nil
+	}
+}

--- a/rest.go
+++ b/rest.go
@@ -108,7 +108,7 @@ func (r *rest) stepDoRequest() (resp *http.Response, body []byte, err error) {
 		return
 	}
 
-	resp, body, err = r.c.req.Do(r.conf.Ctx, r.conf)
+	resp, body, err = r.c.req.Do(r.conf)
 	return
 }
 
@@ -234,7 +234,7 @@ func (b *RESTBuilder) execute() (v interface{}, err error) {
 
 	var resp *http.Response
 	var body []byte
-	resp, body, err = b.client.Do(b.config.Ctx, b.config)
+	resp, body, err = b.client.Do(b.config)
 	if err != nil {
 		return nil, err
 	}
@@ -352,9 +352,10 @@ func (c clientQueryBuilder) WithContext(ctx context.Context) ClientQueryBuilderE
 //  Comment                 This endpoint does not require authentication.
 func (c *Client) GetGateway(ctx context.Context) (gateway *gateway.Gateway, err error) {
 	var body []byte
-	_, body, err = c.req.Do(ctx, &httd.Request{
+	_, body, err = c.req.Do(&httd.Request{
 		Method:   httd.MethodGet,
 		Endpoint: "/gateway",
+		Ctx: ctx,
 	})
 	if err != nil {
 		return
@@ -375,9 +376,10 @@ func (c *Client) GetGateway(ctx context.Context) (gateway *gateway.Gateway, err 
 //  Comment                 This endpoint requires authentication using a valid bot token.
 func (c *Client) GetGatewayBot(ctx context.Context) (gateway *gateway.GatewayBot, err error) {
 	var body []byte
-	_, body, err = c.req.Do(ctx, &httd.Request{
+	_, body, err = c.req.Do(&httd.Request{
 		Method:   httd.MethodGet,
 		Endpoint: "/gateway/bot",
+		Ctx: ctx,
 	})
 	if err != nil {
 		return

--- a/rest_test.go
+++ b/rest_test.go
@@ -25,9 +25,11 @@ type reqMocker struct {
 	req  *httd.Request
 }
 
-func (gm *reqMocker) Do(ctx context.Context, req *httd.Request) (*http.Response, []byte, error) {
+func (gm *reqMocker) Do(req *httd.Request) (*http.Response, []byte, error) {
+	if req.Ctx == nil {
+		req.Ctx = context.Background()
+	}
 	gm.req = req
-	gm.req.Ctx = ctx
 	return gm.resp, gm.body, gm.err
 }
 


### PR DESCRIPTION
# Description

Move rate limiting into the http RoundTripper interface. This also allows custom, or specialized rate limiters to be injected by others.

This change also fixes cpu usage spikes due to an internal "interval checker" being used instead of a system signal/channel on new content.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] I ran `go generate`
- [ ] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
