### PR TITLE
Correct two panics in the caching system

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -157,12 +157,12 @@ func (c *CacheLFUImmutable) ChannelUpdate(data []byte) (*ChannelUpdate, error) {
 	} else {
 		// unlikely
 		tmp := &Channel{}
-		if err := json.Unmarshal(data, channel); err != nil {
+		if err := json.Unmarshal(data, tmp); err != nil {
 			return nil, err
 		}
-		c.Patch(channel)
+		c.Patch(tmp)
 		channel = tmp.DeepCopy().(*Channel)
-		freshItem := c.Channels.CreateCacheableItem(tmp)
+		freshItem := c.Channels.CreateCacheableItem(channel)
 
 		c.Channels.Lock()
 		if existingItem, exists := c.Channels.Get(channelID); !exists {
@@ -278,6 +278,7 @@ func (c *CacheLFUImmutable) GuildMemberRemove(data []byte) (*GuildMemberRemove, 
 				guild.MemberCount--
 				guild.Members[i] = guild.Members[len(guild.Members)-1]
 				guild.Members = guild.Members[:len(guild.Members)-1]
+				break
 			}
 		}
 	}

--- a/cache.go
+++ b/cache.go
@@ -162,7 +162,7 @@ func (c *CacheLFUImmutable) ChannelUpdate(data []byte) (*ChannelUpdate, error) {
 		}
 		c.Patch(tmp)
 		channel = tmp.DeepCopy().(*Channel)
-		freshItem := c.Channels.CreateCacheableItem(channel)
+		freshItem := c.Channels.CreateCacheableItem(tmp)
 
 		c.Channels.Lock()
 		if existingItem, exists := c.Channels.Get(channelID); !exists {


### PR DESCRIPTION
# Description

The first is caused by modifying the cache while it is being iterated on.

The second is caused by incorrectly unmarshalling a channel which occurs most often when the discord connection is being reestablished.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Added benchmarks if this is a performant required component (potential bottlenecks)
