### PR TITLE
Switch uint64 to PermissionBit in Role struct, fix unhandled error warn

### DIFF
--- a/role.go
+++ b/role.go
@@ -48,16 +48,15 @@ func NewRole() *Role {
 
 // Role https://discord.com/developers/docs/topics/permissions#role-object
 type Role struct {
-	ID          Snowflake `json:"id"`
-	Name        string    `json:"name"`
-	Color       uint      `json:"color"`
-	Hoist       bool      `json:"hoist"`
-	Position    int       `json:"position"` // can be -1
-	Permissions uint64    `json:"permissions"`
-	Managed     bool      `json:"managed"`
-	Mentionable bool      `json:"mentionable"`
-
-	guildID Snowflake
+	ID          Snowflake     `json:"id"`
+	Name        string        `json:"name"`
+	Color       uint          `json:"color"`
+	Hoist       bool          `json:"hoist"`
+	Position    int           `json:"position"` // can be -1
+	Permissions PermissionBit `json:"permissions"`
+	Managed     bool          `json:"managed"`
+	Mentionable bool          `json:"mentionable"`
+	guildID     Snowflake
 }
 
 var _ Mentioner = (*Role)(nil)
@@ -83,7 +82,7 @@ func (r *Role) SetGuildID(id Snowflake) {
 // DeepCopy see interface at struct.go#DeepCopier
 func (r *Role) DeepCopy() (copy interface{}) {
 	copy = NewRole()
-	r.CopyOverTo(copy)
+	_ = r.CopyOverTo(copy)
 
 	return
 }


### PR DESCRIPTION
# Description

Changes the Role.Permissions type from uint64 to PermissionBit, this makes it consistent with the rest of the library and also allows it to use the Contains method. This PR also removes an IDE warning caused by ignoring a return value in role.DeepCopy.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
