### PR TITLE
Correct mutex unlocking for guild cache accesses

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -526,7 +526,7 @@ func (c *CacheLFUImmutable) GetChannel(id Snowflake) (*Channel, error) {
 	if exists {
 		mutex := c.Mutex(&c.Channels, id)
 		mutex.Lock()
-		defer mutex.Lock()
+		defer mutex.Unlock()
 
 		channel := cachedItem.Val.(*Channel)
 		return channel.DeepCopy().(*Channel), nil
@@ -541,7 +541,7 @@ func (c *CacheLFUImmutable) GetGuildEmoji(guildID, emojiID Snowflake) (*Emoji, e
 	if exists {
 		mutex := c.Mutex(&c.Guilds, guildID)
 		mutex.Lock()
-		defer mutex.Lock()
+		defer mutex.Unlock()
 
 		guild := cachedItem.Val.(*Guild)
 		emoji, _ := guild.Emoji(emojiID)
@@ -557,7 +557,7 @@ func (c *CacheLFUImmutable) GetGuildEmojis(id Snowflake) ([]*Emoji, error) {
 	if exists {
 		mutex := c.Mutex(&c.Guilds, id)
 		mutex.Lock()
-		defer mutex.Lock()
+		defer mutex.Unlock()
 
 		guild := cachedItem.Val.(*Guild)
 		emojis := make([]*Emoji, len(guild.Emojis))
@@ -578,7 +578,7 @@ func (c *CacheLFUImmutable) GetGuild(id Snowflake) (*Guild, error) {
 	if exists {
 		mutex := c.Mutex(&c.Guilds, id)
 		mutex.Lock()
-		defer mutex.Lock()
+		defer mutex.Unlock()
 
 		guild = cachedItem.Val.(*Guild).DeepCopy().(*Guild)
 	}
@@ -593,7 +593,7 @@ func (c *CacheLFUImmutable) GetGuildChannels(id Snowflake) ([]*Channel, error) {
 	if exists {
 		mutex := c.Mutex(&c.Guilds, id)
 		mutex.Lock()
-		defer mutex.Lock()
+		defer mutex.Unlock()
 
 		guild := cachedItem.Val.(*Guild)
 


### PR DESCRIPTION
# Description

CacheLFUImmutable functions that accessed guilds were incorrectly deferring a call to mutex.Lock() causing the goroutine to block indefinitely.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
