### PR TITLE
Fix locking race condition for CacheLFUImmutable.GetMember

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -633,13 +633,14 @@ func (c *CacheLFUImmutable) GetMember(guildID, userID Snowflake) (*Member, error
 	if exists {
 		mutex := c.Mutex(&c.Users, userID)
 		mutex.Lock()
-		defer mutex.Unlock()
 
 		guild := cachedItem.Val.(*Guild)
 		member, _ = guild.Member(userID)
 		if member != nil {
 			member = member.DeepCopy().(*Member)
 		}
+
+		mutex.Unlock()
 	}
 
 	wg.Wait()


### PR DESCRIPTION
# Description

In the event that the goroutine fetching the User does not outpace the Member fetch it'll block on the lock acquisition due to the Member Unlock being deferred.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
