### PR TITLE
Membership Screening

### DIFF
--- a/events.go
+++ b/events.go
@@ -400,6 +400,7 @@ type GuildMemberUpdate struct {
 	Roles   []Snowflake `json:"roles"`
 	User    *User       `json:"user"`
 	Nick    string      `json:"nick"`
+	Pending bool        `json:"pending"`
 	ShardID uint        `json:"-"`
 }
 

--- a/guild.go
+++ b/guild.go
@@ -502,6 +502,7 @@ type Member struct {
 	PremiumSince Time        `json:"premium_since,omitempty"`
 	Deaf         bool        `json:"deaf"`
 	Mute         bool        `json:"mute"`
+	Pending      bool        `json:"pending"`
 
 	// custom
 	UserID Snowflake `json:"-"`


### PR DESCRIPTION
# Description

Added support for Discord's new membership screening feature by adding the `Pending` property to the `GuildMember` object and the `GuildMemberUpdate` event as per the [Discord API documentation](https://discord.com/developers/docs/resources/guild#guild-member-object-guild-member-structure). 

The `Pending` property will always be `false` on a guild with Membership Screening disabled. In guilds which have it enabled, `Pending` will be `true` for new members, and when a member gets screened Discord fires a `GuildMemberUpdate` event with the `Pending` property set to `false`.

I have tested these changes work correctly.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
