### PR TITLE
Patch in guildID for cached members

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,7 @@ repos:
         #
         # Formatters
         -   id: go-fmt
-        -   id: go-imports # Replaces go-fmt
+        #-   id: go-imports
         #
         # Style Checkers
         #

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -582,6 +582,20 @@ func TestREST(t *testing.T) {
 	})
 
 	// -------------------
+	// Members
+	// -------------------
+	t.Run("members", func(t *testing.T) {
+		members, err := c.Guild(guildTypical.ID).GetMembers(nil, IgnoreCache)
+		if err != nil {
+			t.Error("failed to fetched members over REST, ", err)
+		}
+
+		if len(members) > 0 {
+			t.Error("expected there to be members. None found.")
+		}
+	})
+
+	// -------------------
 	// Audit Logs
 	// -------------------
 	// t.Run("audit-logs", func(t *testing.T) {

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -590,7 +590,7 @@ func TestREST(t *testing.T) {
 			t.Error("failed to fetched members over REST, ", err)
 		}
 
-		if len(members) > 0 {
+		if len(members) == 0 {
 			t.Error("expected there to be members. None found.")
 		}
 	})

--- a/guild.go
+++ b/guild.go
@@ -191,6 +191,7 @@ func (g *Guild) updateInternals() {
 		g.Channels[i].GuildID = g.ID
 	}
 	for i := range g.Members {
+		g.Members[i].GuildID = g.ID
 		g.Members[i].updateInternals()
 	}
 }

--- a/guild.go
+++ b/guild.go
@@ -1508,6 +1508,14 @@ func (g guildQueryBuilder) getGuildMembers(params *getGuildMembersParams, flags 
 		return nil, err
 	}
 
+	if !ignoreCache(flags...) {
+		p := &GetMembersParams{After: params.After, Limit: uint32(params.Limit)}
+		members, err := g.client.cache.GetMembers(g.gid, p)
+		if err == nil && len(members) > 0 {
+			return members, nil
+		}
+	}
+
 	r := g.client.newRESTRequest(&httd.Request{
 		Endpoint: endpoint.GuildMembers(g.gid) + params.URLQueryString(),
 		Ctx:      g.ctx,

--- a/member.go
+++ b/member.go
@@ -41,7 +41,6 @@ func (g guildMemberQueryBuilder) WithContext(ctx context.Context) GuildMemberQue
 func (g guildMemberQueryBuilder) Get(flags ...Flag) (*Member, error) {
 	if !ignoreCache(flags...) {
 		if member, _ := g.client.cache.GetMember(g.gid, g.uid); member != nil {
-			member.GuildID = g.gid
 			return member, nil
 		}
 	}

--- a/member.go
+++ b/member.go
@@ -41,6 +41,7 @@ func (g guildMemberQueryBuilder) WithContext(ctx context.Context) GuildMemberQue
 func (g guildMemberQueryBuilder) Get(flags ...Flag) (*Member, error) {
 	if !ignoreCache(flags...) {
 		if member, _ := g.client.cache.GetMember(g.gid, g.uid); member != nil {
+			member.GuildID = g.gid
 			return member, nil
 		}
 	}


### PR DESCRIPTION
# Description
This PR patches in the guild ID for cached members as well as non cached members when fetched, previously for cached members a zeroed guild ID was returned, which broke other functionality.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I ran `go generate`
- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
