### PR TITLE
Fix return value in HasPermissions in std.msgFilter

### DIFF
--- a/std/msgfilter.go
+++ b/std/msgfilter.go
@@ -122,7 +122,7 @@ func (f *msgFilter) HasPermissions(evt interface{}) interface{} {
 		return nil
 	}
 
-	return msg
+	return evt
 }
 
 // SetMinPermissions enforces message authors to have at least the given permission flags


### PR DESCRIPTION
# Description

The HasPermissions function for the std.msgFilter was returning the message instead of the event when an event passed the tests. Changed to return the event instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I ran `go generate`
- [ ] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
