### PR TITLE
Fix update presence activities

### DIFF
--- a/client.go
+++ b/client.go
@@ -511,9 +511,11 @@ func (c *Client) UpdateStatus(s *UpdateStatusPayload) error {
 func (c *Client) UpdateStatusString(s string) error {
 	updateData := &UpdateStatusPayload{
 		Since: nil,
-		Game: &Activity{
-			Name: s,
-			Type: 0,
+		Game: []*Activity{
+			{
+				Name: s,
+				Type: ActivityTypeGame,
+			},
 		},
 		Status: StatusOnline,
 		AFK:    false,

--- a/internal/gateway/packets.go
+++ b/internal/gateway/packets.go
@@ -169,7 +169,7 @@ type UpdateStatusPayload struct {
 	Since *uint `json:"since"`
 
 	// Game null, or the user's new activity
-	Game interface{} `json:"game"`
+	Game interface{} `json:"activities"`
 
 	// Status the user's new status
 	Status string `json:"status"`

--- a/user.go
+++ b/user.go
@@ -119,18 +119,18 @@ const (
 type Activity struct {
 	Name          string             `json:"name"`
 	Type          ActivityType       `json:"type"`
-	URL           string             `json:"url"`
+	URL           string             `json:"url,omitempty"`
 	CreatedAt     int                `json:"created_at"`
-	Timestamps    *ActivityTimestamp `json:"timestamps"`
-	ApplicationID Snowflake          `json:"application_id"`
-	Details       string             `json:"details"`
-	State         string             `json:"state"`
-	Emoji         *ActivityEmoji     `json:"emoji"`
-	Party         *ActivityParty     `json:"party"`
-	Assets        *ActivityAssets    `json:"assets"`
-	Secrets       *ActivitySecrets   `json:"secrets"`
-	Instance      bool               `json:"instance"`
-	Flags         ActivityFlag       `json:"flags"`
+	Timestamps    *ActivityTimestamp `json:"timestamps,omitempty"`
+	ApplicationID Snowflake          `json:"application_id,omitempty"`
+	Details       string             `json:"details,omitempty"`
+	State         string             `json:"state,omitempty"`
+	Emoji         *ActivityEmoji     `json:"emoji,omitempty"`
+	Party         *ActivityParty     `json:"party,omitempty"`
+	Assets        *ActivityAssets    `json:"assets,omitempty"`
+	Secrets       *ActivitySecrets   `json:"secrets,omitempty"`
+	Instance      bool               `json:"instance,omitempty"`
+	Flags         ActivityFlag       `json:"flags,omitempty"`
 }
 
 var _ Reseter = (*Activity)(nil)


### PR DESCRIPTION
# Description

Fixes the update status endpoints, for the presence system. Changes UpdateStatusPayload.Game to json into activities, and marks most fields in Activity to omitempty in json.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I ran `go generate`
- [ ] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
