### PR TITLE
Change Guild.Member to use Member.UserID instead of Member.User.ID to…

### DIFF
--- a/guild.go
+++ b/guild.go
@@ -340,7 +340,7 @@ func (g *Guild) AddRole(role *Role) error {
 // Member return a member by his/her userid
 func (g *Guild) Member(id Snowflake) (*Member, error) {
 	for _, member := range g.Members {
-		if member.User.ID == id {
+		if member.UserID == id {
 			return member, nil
 		}
 	}


### PR DESCRIPTION
… allow cache usage

# Description

Due to the User on cached Member objects being nil at the time this check is done it results in a nil pointer dereference, this change allows it to work as intended.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code (remember to run `go fmt ./...`)
