### PR TITLE
Added message components

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -917,12 +917,12 @@ func (f *CreateMessageFileParams) write(i int, mp *multipart.Writer) error {
 
 // CreateMessageParams JSON params for CreateChannelMessage
 type CreateMessageParams struct {
-	Content string `json:"content"`
-	Nonce   string `json:"nonce,omitempty"` // THIS IS A STRING. NOT A SNOWFLAKE! DONT TOUCH!
-	Tts     bool   `json:"tts,omitempty"`
-	Embed   *Embed `json:"embed,omitempty"` // embedded rich content
-
-	Files []CreateMessageFileParams `json:"-"` // Always omit as this is included in multipart, not JSON payload
+	Content    string                    `json:"content"`
+	Nonce      string                    `json:"nonce,omitempty"` // THIS IS A STRING. NOT A SNOWFLAKE! DONT TOUCH!
+	Tts        bool                      `json:"tts,omitempty"`
+	Embed      *Embed                    `json:"embed,omitempty"` // embedded rich content
+	Components []*MessageComponent       `json:"components"`
+	Files      []CreateMessageFileParams `json:"-"` // Always omit as this is included in multipart, not JSON payload
 
 	SpoilerTagContent        bool `json:"-"`
 	SpoilerTagAllAttachments bool `json:"-"`

--- a/message.go
+++ b/message.go
@@ -82,6 +82,36 @@ type MessageReference struct {
 	GuildID   Snowflake `json:"guild_id"`
 }
 
+type MessageComponentType = int
+
+const (
+	_ MessageComponentType = iota
+	MessageComponentActionRow
+	MessageComponentButton
+)
+
+type ButtonStyle = int
+
+const (
+	_ ButtonStyle = iota
+	Primary
+	Secondary
+	Success
+	Danger
+	Link
+)
+
+type MessageComponent struct {
+	Type       MessageComponentType `json:"type"`
+	Style      ButtonStyle          `json:"style"`
+	Label      string               `json:"label"`
+	Emoji      *Emoji               `json:"emoji"`
+	CustomID   string               `json:"custom_id"`
+	Url        string               `json:"url"`
+	Disabled   bool                 `json:"disabled"`
+	Components []*MessageComponent  `json:"components"`
+}
+
 // MessageApplication https://discord.com/developers/docs/resources/channel#message-object-message-application-structure
 type MessageApplication struct {
 	ID          Snowflake `json:"id"`
@@ -116,32 +146,33 @@ var _ DeepCopier = (*MessageSticker)(nil)
 
 // Message https://discord.com/developers/docs/resources/channel#message-object-message-structure
 type Message struct {
-	ID                Snowflake          `json:"id"`
-	ChannelID         Snowflake          `json:"channel_id"`
-	GuildID           Snowflake          `json:"guild_id"`
-	Author            *User              `json:"author"`
-	Member            *Member            `json:"member"`
-	Content           string             `json:"content"`
-	Timestamp         Time               `json:"timestamp"`
-	EditedTimestamp   Time               `json:"edited_timestamp"` // ?
-	Tts               bool               `json:"tts"`
-	MentionEveryone   bool               `json:"mention_everyone"`
-	Mentions          []*User            `json:"mentions"`
-	MentionRoles      []Snowflake        `json:"mention_roles"`
-	MentionChannels   []*MentionChannel  `json:"mention_channels"`
-	Attachments       []*Attachment      `json:"attachments"`
-	Embeds            []*Embed           `json:"embeds"`
-	Reactions         []*Reaction        `json:"reactions"` // ?
-	Nonce             interface{}        `json:"nonce"`     // NOT A SNOWFLAKE! DONT TOUCH!
-	Pinned            bool               `json:"pinned"`
-	WebhookID         Snowflake          `json:"webhook_id"` // ?
-	Type              MessageType        `json:"type"`
-	Activity          MessageActivity    `json:"activity"`
-	Application       MessageApplication `json:"application"`
-	MessageReference  *MessageReference  `json:"message_reference"`
-	ReferencedMessage *Message           `json:"referenced_message"`
-	Flags             MessageFlag        `json:"flags"`
-	Stickers          []*MessageSticker  `json:"stickers"`
+	ID                Snowflake           `json:"id"`
+	ChannelID         Snowflake           `json:"channel_id"`
+	GuildID           Snowflake           `json:"guild_id"`
+	Author            *User               `json:"author"`
+	Member            *Member             `json:"member"`
+	Content           string              `json:"content"`
+	Timestamp         Time                `json:"timestamp"`
+	EditedTimestamp   Time                `json:"edited_timestamp"` // ?
+	Tts               bool                `json:"tts"`
+	MentionEveryone   bool                `json:"mention_everyone"`
+	Mentions          []*User             `json:"mentions"`
+	MentionRoles      []Snowflake         `json:"mention_roles"`
+	MentionChannels   []*MentionChannel   `json:"mention_channels"`
+	Attachments       []*Attachment       `json:"attachments"`
+	Embeds            []*Embed            `json:"embeds"`
+	Reactions         []*Reaction         `json:"reactions"` // ?
+	Nonce             interface{}         `json:"nonce"`     // NOT A SNOWFLAKE! DONT TOUCH!
+	Pinned            bool                `json:"pinned"`
+	WebhookID         Snowflake           `json:"webhook_id"` // ?
+	Type              MessageType         `json:"type"`
+	Activity          MessageActivity     `json:"activity"`
+	Application       MessageApplication  `json:"application"`
+	MessageReference  *MessageReference   `json:"message_reference"`
+	ReferencedMessage *Message            `json:"referenced_message"`
+	Flags             MessageFlag         `json:"flags"`
+	Stickers          []*MessageSticker   `json:"stickers"`
+	Components        []*MessageComponent `json:"components"`
 
 	// SpoilerTagContent is only true if the entire message text is tagged as a spoiler (aka completely wrapped in ||)
 	SpoilerTagContent        bool `json:"-"`

--- a/rest.go
+++ b/rest.go
@@ -377,6 +377,7 @@ func (c clientQueryBuilder) SendMsg(channelID Snowflake, data ...interface{}) (m
 			}
 
 			params.Content = m.Content
+			params.Components = m.Components
 			params.SpoilerTagAllAttachments = m.SpoilerTagAllAttachments
 			params.SpoilerTagContent = m.SpoilerTagContent
 			params.Tts = m.Tts


### PR DESCRIPTION
# Description

This pull request adds [Message components](https://discord.com/developers/docs/interactions/message-component) to the Message object.

Example: 

```go

msg.Reply(context.Background(), session, &disgord.Message{
        Content: "Test",
	Components: []*disgord.MessageComponent{
		{
			Type: disgord.MessageComponentActionRow,
			Components: []*disgord.MessageComponent{
				{
					Type:     disgord.MessageComponentButton,
					Label:    "click me",
					Style:    disgord.Primary,
					CustomID: "click_one",
				},
			},
		},
	},
})
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I ran `go generate`
- [ ] I have performed a self-review of my own code (remember to run `go fmt ./...`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added benchmarks if this is a performant required component (potential bottlenecks)
