### PR TITLE
patch arm 64bit int crash

### DIFF
--- a/internal/gateway/client.go
+++ b/internal/gateway/client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
-	"strconv"
 	"sync"
 	"time"
 

--- a/internal/gateway/client.go
+++ b/internal/gateway/client.go
@@ -253,7 +253,7 @@ func (c *client) getLogPrefix() string {
 	}
 
 	nr := c.logSequence.Add(1)
-	return fmt.Sprintf("[ws-%s,s:%d,shard:%s]", t, nr, c.ShardID)
+	return fmt.Sprintf("[ws-%s,s:%d,shard:%d]", t, nr, c.ShardID)
 }
 
 //////////////////////////////////////////////////////

--- a/internal/gateway/client.go
+++ b/internal/gateway/client.go
@@ -254,7 +254,7 @@ func (c *client) getLogPrefix() string {
 	}
 
 	nr := c.logSequence.Add(1)
-	s := "s:" + strconv.FormatUint(uint64(nr), 10)
+	s := fmt.Sprintf("s:%d", nr)
 	shardID := "shard:" + strconv.FormatUint(uint64(c.ShardID), 10)
 
 	// [ws-?, s:0, shard:0]

--- a/internal/gateway/client.go
+++ b/internal/gateway/client.go
@@ -244,7 +244,7 @@ func (c *client) inactivityDetector() {
 //////////////////////////////////////////////////////
 
 func (c *client) getLogPrefix() string {
-	t := "ws-"
+	var t string
 	if c.clientType == clientTypeVoice {
 		t += "v"
 	} else if c.clientType == clientTypeEvent {
@@ -254,12 +254,7 @@ func (c *client) getLogPrefix() string {
 	}
 
 	nr := c.logSequence.Add(1)
-	s := fmt.Sprintf("s:%d", nr)
-	
-	shardID := fmt.Sprintf("shard:%d", c.ShardID)
-
-	// [ws-?, s:0, shard:0]
-	return fmt.Sprintf("[%s,%s,%s]", t, s , shardID)
+	return fmt.Sprintf("[ws-%s,s:%d,shard:%s]", t, nr, c.ShardID)
 }
 
 //////////////////////////////////////////////////////

--- a/internal/gateway/client.go
+++ b/internal/gateway/client.go
@@ -255,10 +255,11 @@ func (c *client) getLogPrefix() string {
 
 	nr := c.logSequence.Add(1)
 	s := fmt.Sprintf("s:%d", nr)
-	shardID := "shard:" + strconv.FormatUint(uint64(c.ShardID), 10)
+	
+	shardID := fmt.Sprintf("shard:%d", c.ShardID)
 
 	// [ws-?, s:0, shard:0]
-	return "[" + t + "," + s + "," + shardID + "]"
+	return fmt.Sprintf("[%s,%s,%s]", t, s , shardID)
 }
 
 //////////////////////////////////////////////////////


### PR DESCRIPTION
# Description
Causes crash on arm processors:

 - https://github.com/Vedza/NitroSniperGo/issues/320
 - https://github.com/Vedza/NitroSniperGo/issues/303

The uint32 to uint64 cast was completely redundant, and only caused issues.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I ran `go generate`
- [ ] I ran `go fmt ./...`
- [ ] I have performed a self-review of my own code
- [ ] Commented complex situations or referenced the discord documentation
- [ ] Updated documentation
- [ ] Added/Updated unit tests
- [ ] Added/Updated benchmarks (if this is a performance critical component)
