### PR TITLE
Add available field to emoji

### DIFF
--- a/emoji.go
+++ b/emoji.go
@@ -27,6 +27,7 @@ type Emoji struct {
 	RequireColons bool        `json:"require_colons,omitempty"`
 	Managed       bool        `json:"managed,omitempty"`
 	Animated      bool        `json:"animated,omitempty"`
+	Available     bool        `json:"available,omitempty"`
 }
 
 var _ Reseter = (*Emoji)(nil)

--- a/iface_copier_gen.go
+++ b/iface_copier_gen.go
@@ -351,6 +351,7 @@ func (e *Emoji) copyOverTo(other interface{}) error {
 		return newErrorUnsupportedType("argument given is not a *Emoji type")
 	}
 	dest.Animated = e.Animated
+	dest.Available = e.Available
 	dest.ID = e.ID
 	dest.Managed = e.Managed
 	dest.Name = e.Name

--- a/iface_reseter_gen.go
+++ b/iface_reseter_gen.go
@@ -42,6 +42,7 @@ func (c *Channel) reset() {
 
 func (e *Emoji) reset() {
 	e.Animated = false
+	e.Available = false
 	e.ID = 0
 	e.Managed = false
 	e.Name = ""


### PR DESCRIPTION
# Description
The `available` field was missing in the Emoji structure ([ref](https://discord.com/developers/docs/resources/emoji#emoji-object-emoji-structure)). This PR adds it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I ran `go generate`
- [x] I ran `go fmt ./...`
- [x] I have performed a self-review of my own code
