### PR TITLE
Add additional guild fields

### DIFF
--- a/guild.go
+++ b/guild.go
@@ -161,6 +161,12 @@ type Guild struct {
 	WidgetEnabled               bool                          `json:"widget_enabled,omit_empty"`    //   |
 	WidgetChannelID             Snowflake                     `json:"widget_channel_id,omit_empty"` //   |?
 	SystemChannelID             Snowflake                     `json:"system_channel_id,omitempty"`  //   |?
+	DiscoverySplash             string                        `json:"discovery_splash,omitempty"`
+	VanityUrl                   string                        `json:"vanity_url_code,omitempty"`
+	Description                 string                        `json:"description,omitempty"`
+	Banner                      string                        `json:"banner,omitempty"`
+	PremiumTier                 PremiumTier                   `json:"premium_tier"`
+	PremiumSubscriptionCount    uint                          `json:"premium_subscription_count,omitempty"`
 
 	// JoinedAt must be a pointer, as we can't hide non-nil structs
 	JoinedAt    *Time           `json:"joined_at,omitempty"`    // ?*|

--- a/iface_copier_gen.go
+++ b/iface_copier_gen.go
@@ -372,11 +372,14 @@ func (g *Guild) copyOverTo(other interface{}) error {
 	dest.AfkChannelID = g.AfkChannelID
 	dest.AfkTimeout = g.AfkTimeout
 	dest.ApplicationID = g.ApplicationID
+	dest.Banner = g.Banner
 	dest.Channels = make([]*Channel, len(g.Channels))
 	for i := 0; i < len(g.Channels); i++ {
 		dest.Channels[i] = DeepCopy(g.Channels[i]).(*Channel)
 	}
 	dest.DefaultMessageNotifications = g.DefaultMessageNotifications
+	dest.Description = g.Description
+	dest.DiscoverySplash = g.DiscoverySplash
 	dest.Emojis = make([]*Emoji, len(g.Emojis))
 	for i := 0; i < len(g.Emojis); i++ {
 		dest.Emojis[i] = DeepCopy(g.Emojis[i]).(*Emoji)
@@ -398,6 +401,8 @@ func (g *Guild) copyOverTo(other interface{}) error {
 	dest.Owner = g.Owner
 	dest.OwnerID = g.OwnerID
 	dest.Permissions = g.Permissions
+	dest.PremiumSubscriptionCount = g.PremiumSubscriptionCount
+	dest.PremiumTier = g.PremiumTier
 	dest.Presences = make([]*UserPresence, len(g.Presences))
 	for i := 0; i < len(g.Presences); i++ {
 		dest.Presences[i] = DeepCopy(g.Presences[i]).(*UserPresence)
@@ -410,6 +415,7 @@ func (g *Guild) copyOverTo(other interface{}) error {
 	dest.Splash = g.Splash
 	dest.SystemChannelID = g.SystemChannelID
 	dest.Unavailable = g.Unavailable
+	dest.VanityUrl = g.VanityUrl
 	dest.VerificationLevel = g.VerificationLevel
 	dest.VoiceStates = make([]*VoiceState, len(g.VoiceStates))
 	for i := 0; i < len(g.VoiceStates); i++ {

--- a/iface_reseter_gen.go
+++ b/iface_reseter_gen.go
@@ -57,8 +57,11 @@ func (g *Guild) reset() {
 	g.AfkChannelID = 0
 	g.AfkTimeout = 0
 	g.ApplicationID = 0
+	g.Banner = ""
 	g.Channels = nil
 	g.DefaultMessageNotifications = 0
+	g.Description = ""
+	g.DiscoverySplash = ""
 	g.Emojis = nil
 	g.ExplicitContentFilter = 0
 	g.Features = nil
@@ -73,12 +76,15 @@ func (g *Guild) reset() {
 	g.Owner = false
 	g.OwnerID = 0
 	g.Permissions = 0
+	g.PremiumSubscriptionCount = 0
+	g.PremiumTier = 0
 	g.Presences = nil
 	g.Region = ""
 	g.Roles = nil
 	g.Splash = ""
 	g.SystemChannelID = 0
 	g.Unavailable = false
+	g.VanityUrl = ""
 	g.VerificationLevel = 0
 	g.VoiceStates = nil
 	g.WidgetChannelID = 0

--- a/struct.go
+++ b/struct.go
@@ -200,6 +200,18 @@ func (vl *VerificationLvl) VeryHigh() bool {
 	return *vl == VerificationLvlVeryHigh
 }
 
+// PremiumTier ...
+// https://discord.com/developers/docs/resources/guild#guild-object-premium-tier
+type PremiumTier uint
+
+// the different premium tier levels
+const (
+	PremiumTierNone PremiumTier = iota
+	PremiumTier1
+	PremiumTier2
+	PremiumTier3
+)
+
 // DefaultMessageNotificationLvl ...
 // https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level
 type DefaultMessageNotificationLvl uint


### PR DESCRIPTION
# Description
This PR adds some additional fields for the guild object ([ref](https://discord.com/developers/docs/resources/guild#guild-object)) like vanity url, discovery splash, description, etc. It also adds a new PremiumTier type for boosted servers. 

The PremiumTier type was placed directly below the VerificationLvl type, the idea was to group guild related types. If this isn't the best place, let me know and I'll make the change!

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I ran `go generate`
- [x] I ran `go fmt ./...`
- [x] I have performed a self-review of my own code
- [x] Commented complex situations or referenced the discord documentation
