### PR TITLE
Fixes #412

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -211,9 +211,10 @@ func (c *Channel) SendMsg(ctx context.Context, s Session, message *Message) (msg
 	}
 
 	params := &CreateMessageParams{
-		Content: message.Content,
-		Nonce:   nonce, // THIS IS A STRING. NOT A SNOWFLAKE! DONT TOUCH!
-		Tts:     message.Tts,
+		Content:          message.Content,
+		Nonce:            nonce, // THIS IS A STRING. NOT A SNOWFLAKE! DONT TOUCH!
+		Tts:              message.Tts,
+		MessageReference: message.MessageReference,
 		// File: ...
 		// Embed: ...
 	}

--- a/message.go
+++ b/message.go
@@ -254,9 +254,10 @@ func (m *Message) Send(ctx context.Context, s Session, flags ...Flag) (msg *Mess
 
 	// TODO: attachments
 	params := &CreateMessageParams{
-		Content: m.Content,
-		Tts:     m.Tts,
-		Nonce:   nonce,
+		Content:          m.Content,
+		Tts:              m.Tts,
+		MessageReference: m.MessageReference,
+		Nonce:            nonce,
 		// File: ...
 		// Embed: ...
 	}

--- a/rest.go
+++ b/rest.go
@@ -378,6 +378,7 @@ func (c clientQueryBuilder) SendMsg(channelID Snowflake, data ...interface{}) (m
 
 			params.Content = m.Content
 			params.Components = m.Components
+			params.MessageReference = m.MessageReference
 			params.SpoilerTagAllAttachments = m.SpoilerTagAllAttachments
 			params.SpoilerTagContent = m.SpoilerTagContent
 			params.Tts = m.Tts


### PR DESCRIPTION
CreateMessageParams that are automatically created (via .Send, .SendMsg, and .Reply) should now respect Message.MessageReference where appropriate. This was previously not included so it wasn't very intuitive for how to quickly reply to a message and include that original message as a reference.

# Description
Included code that copies MessageReference from the Message object to the CreateMessageParams object when other params are copied. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Benchmarks
N/A

# Checklist:

- [N/A] I ran `go generate`
- [X] I ran `go fmt ./...`
- [X] I have performed a self-review of my own code
- [N/A] Commented complex situations or referenced the discord documentation
- [N/A] Updated documentation
- [N/A] Added/Updated unit tests
- [N/A] Added/Updated benchmarks (if this is a performance critical component)
