### PR TITLE
Move to Discord API v9

### DIFF
--- a/internal/constant/communication.go
+++ b/internal/constant/communication.go
@@ -1,7 +1,7 @@
 package constant
 
 // DiscordVersion API version
-const DiscordVersion = 8
+const DiscordVersion = 9
 
 // JSONEncoding the json encoding identifier
 const JSONEncoding = "json"

--- a/internal/httd/client.go
+++ b/internal/httd/client.go
@@ -101,7 +101,7 @@ func (c *Client) BucketGrouping() (group map[string][]string) {
 // SupportsDiscordAPIVersion check if a given discord api version is supported by this package.
 func SupportsDiscordAPIVersion(version int) bool {
 	supports := []int{
-		8,
+		9,
 	}
 
 	var supported bool


### PR DESCRIPTION
# Description
Changed Discord API version from v8 to v9. This is required in order to receive CreateMessage events in threads.
Future changes required for full Thread support.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [X] I have performed a self-review of my own code
