### PR TITLE
fix: make rest builders return an exported interface

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -246,7 +246,7 @@ type ChannelQueryBuilder interface {
 	// a channel on success, and a 400 BAD REQUEST on invalid parameters. Fires a Channel Update Gateway event. If
 	// modifying a category, individual Channel Update events will fire for each child channel that also changes.
 	// For the PATCH method, all the JSON Params are optional.
-	UpdateBuilder() *updateChannelBuilder
+	UpdateBuilder() UpdateChannelBuilder
 
 	// Delete Delete a channel, or close a private message. Requires the 'MANAGE_CHANNELS' permission for
 	// the guild. Deleting a category does not delete its child Channels; they will have their parent_id removed and a
@@ -372,8 +372,8 @@ func (c channelQueryBuilder) Get() (*Channel, error) {
 //  Discord documentation   https://discord.com/developers/docs/resources/channel#modify-channel
 //  Reviewed                2018-06-07
 //  Comment                 andersfylling: only implemented the patch method, as its parameters are optional.
-func (c channelQueryBuilder) UpdateBuilder() (builder *updateChannelBuilder) {
-	builder = &updateChannelBuilder{}
+func (c channelQueryBuilder) UpdateBuilder() UpdateChannelBuilder {
+	builder := &updateChannelBuilder{}
 	builder.r.itemFactory = func() interface{} {
 		return c.client.pool.channel.Get()
 	}

--- a/message.go
+++ b/message.go
@@ -337,7 +337,7 @@ type MessageQueryBuilder interface {
 
 	// UpdateBuilder Edit a previously sent message. You can only edit messages that have been sent by the
 	// current user. Returns a message object. Fires a Message Update Gateway event.
-	UpdateBuilder() *updateMessageBuilder
+	UpdateBuilder() UpdateMessageBuilder
 	SetContent(content string) (*Message, error)
 	SetEmbed(embed *Embed) (*Message, error)
 
@@ -419,8 +419,8 @@ func (m messageQueryBuilder) Get() (*Message, error) {
 //  Discord documentation   https://discord.com/developers/docs/resources/channel#edit-message
 //  Reviewed                2018-06-10
 //  Comment                 All parameters to this endpoint are optional.
-func (m messageQueryBuilder) UpdateBuilder() (builder *updateMessageBuilder) {
-	builder = &updateMessageBuilder{}
+func (m messageQueryBuilder) UpdateBuilder() UpdateMessageBuilder {
+	builder := &updateMessageBuilder{}
 	builder.r.itemFactory = func() interface{} {
 		return &Message{}
 	}

--- a/voice.go
+++ b/voice.go
@@ -141,7 +141,7 @@ type VoiceChannelQueryBuilder interface {
 	// a channel on success, and a 400 BAD REQUEST on invalid parameters. Fires a Channel Update Gateway event. If
 	// modifying a category, individual Channel Update events will fire for each child channel that also changes.
 	// For the PATCH method, all the JSON Params are optional.
-	UpdateBuilder() *updateChannelBuilder
+	UpdateBuilder() UpdateChannelBuilder
 
 	// Delete Delete a channel, or close a private message. Requires the 'MANAGE_CHANNELS' permission for
 	// the guild. Deleting a category does not delete its child Channels; they will have their parent_id removed and a

--- a/webhook.go
+++ b/webhook.go
@@ -38,7 +38,7 @@ type WebhookQueryBuilder interface {
 
 	// UpdateBuilder Modify a webhook. Requires the 'MANAGE_WEBHOOKS' permission.
 	// Returns the updated webhook object on success.
-	UpdateBuilder() *updateWebhookBuilder
+	UpdateBuilder() UpdateWebhookBuilder
 
 	// Delete Deletes a webhook permanently. User must be owner. Returns a 204 NO CONTENT response on success.
 	Delete() error
@@ -102,8 +102,8 @@ func (w webhookQueryBuilder) Get() (ret *Webhook, err error) {
 //  Discord documentation   https://discord.com/developers/docs/resources/webhook#modify-webhook
 //  Reviewed                2018-08-14
 //  Comment                 All parameters to this endpoint.
-func (w webhookQueryBuilder) UpdateBuilder() (builder *updateWebhookBuilder) {
-	builder = &updateWebhookBuilder{}
+func (w webhookQueryBuilder) UpdateBuilder() UpdateWebhookBuilder {
+	builder := &updateWebhookBuilder{}
 	builder.r.itemFactory = func() interface{} {
 		return &Webhook{}
 	}
@@ -184,7 +184,7 @@ type WebhookWithTokenQueryBuilder interface {
 
 	// UpdateBuilder Same as UpdateWebhook, except this call does not require authentication,
 	// does _not_ accept a channel_id parameter in the body, and does not return a user in the webhook object.
-	UpdateBuilder() *updateWebhookBuilder
+	UpdateBuilder() UpdateWebhookBuilder
 
 	// Delete Same as DeleteWebhook, except this call does not require authentication.
 	Delete() error
@@ -241,8 +241,8 @@ func (w webhookWithTokenQueryBuilder) Get() (*Webhook, error) {
 //  Discord documentation   https://discord.com/developers/docs/resources/webhook#modify-webhook-with-token
 //  Reviewed                2018-08-14
 //  Comment                 All parameters to this endpoint. are optional.
-func (w webhookWithTokenQueryBuilder) UpdateBuilder() (builder *updateWebhookBuilder) {
-	builder = &updateWebhookBuilder{}
+func (w webhookWithTokenQueryBuilder) UpdateBuilder() UpdateWebhookBuilder {
+	builder := &updateWebhookBuilder{}
 	builder.r.itemFactory = func() interface{} {
 		return &Webhook{}
 	}


### PR DESCRIPTION
Noticed that some interfaces for the REST methods returned a unexported type. Which is yikes for testing.

## Breaking Change?
<!--
if this is a breaking change please write "yes" or "no".
-->
no

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] Commented complex situations or referenced the discord documentation
- [ ] Updated documentation
- [ ] Added/Updated unit tests
- [ ] Added/Updated benchmarks (if this is a performance critical component)
