### PR TITLE
fix: use exported interfaces for builders

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -267,7 +267,7 @@ type ChannelQueryBuilder interface {
 	// the CREATE_INSTANT_INVITE permission. All JSON parameters for this route are optional, however the request
 	// body is not. If you are not sending any fields, you still have to send an empty JSON object ({}).
 	// Returns an invite object.
-	CreateInvite() *createChannelInviteBuilder
+	CreateInvite() CreateChannelInviteBuilder
 
 	// DeletePermission Delete a channel permission overwrite for a user or role in a channel. Only usable
 	// for guild Channels. Requires the 'MANAGE_ROLES' permission. Returns a 204 empty response on success. For more
@@ -506,8 +506,8 @@ func (c channelQueryBuilder) GetInvites() (invites []*Invite, err error) {
 //  Discord documentation   https://discord.com/developers/docs/resources/channel#create-channel-invite
 //  Reviewed                2018-06-07
 //  Comment                 -
-func (c channelQueryBuilder) CreateInvite() (builder *createChannelInviteBuilder) {
-	builder = &createChannelInviteBuilder{}
+func (c channelQueryBuilder) CreateInvite() CreateChannelInviteBuilder {
+	builder := &createChannelInviteBuilder{}
 	builder.r.itemFactory = func() interface{} {
 		return &Invite{}
 	}

--- a/voice.go
+++ b/voice.go
@@ -162,7 +162,7 @@ type VoiceChannelQueryBuilder interface {
 	// the CREATE_INSTANT_INVITE permission. All JSON parameters for this route are optional, however the request
 	// body is not. If you are not sending any fields, you still have to send an empty JSON object ({}).
 	// Returns an invite object.
-	CreateInvite() *createChannelInviteBuilder
+	CreateInvite() CreateChannelInviteBuilder
 
 	// DeletePermission Delete a channel permission overwrite for a user or role in a channel. Only usable
 	// for guild Channels. Requires the 'MANAGE_ROLES' permission. Returns a 204 empty response on success. For more


### PR DESCRIPTION
# Description
Noticed that it wasn't just update builders that had this issue. This should fix all related methods.

## Breaking Change?
<!--
if this is a breaking change please write "yes" or "no".
-->
no

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] Commented complex situations or referenced the discord documentation
- [ ] Updated documentation
- [ ] Added/Updated unit tests
- [ ] Added/Updated benchmarks (if this is a performance critical component)
