### PR TITLE
fix: Mention() for animated emojis

### DIFF
--- a/emoji.go
+++ b/emoji.go
@@ -47,12 +47,12 @@ type PartialEmoji = Emoji
 
 // Mention mentions an emoji. Adds the animation prefix, if animated
 func (e *Emoji) Mention() string {
-	prefix := ""
+	prefix := ":"
 	if e.Animated {
 		prefix = "a:"
 	}
 
-	return "<:" + prefix + e.Name + ":" + e.ID.String() + ">"
+	return "<" + prefix + e.Name + ":" + e.ID.String() + ">"
 }
 
 //////////////////////////////////////////////////////


### PR DESCRIPTION
# Description

Correct syntax for animated emojis is `<a:emoji_name:1234567890>`, removed the extra `:` before `a` which broke their mentions.

## Breaking Change?

No, it is an unbreaking change.

# Checklist:

- [X] I have performed a self-review of my own code
