### PR TITLE
chore: remove custom http method type

### DIFF
--- a/auditlog_test.go
+++ b/auditlog_test.go
@@ -115,7 +115,7 @@ func TestGuildAuditLogs(t *testing.T) {
 		builder := &guildAuditLogsBuilder{}
 		builder.r.itemFactory = auditLogFactory
 		builder.r.IgnoreCache().setup(client, &httd.Request{
-			Method:   httd.MethodGet,
+			Method:   http.MethodGet,
 			Endpoint: endpoint.GuildAuditLogs(Snowflake(7)),
 			Ctx:      context.Background(),
 		}, nil)
@@ -141,7 +141,7 @@ func TestGuildAuditLogs(t *testing.T) {
 
 		builder := &guildAuditLogsBuilder{}
 		builder.r.IgnoreCache().setup(client, &httd.Request{
-			Method:   httd.MethodGet,
+			Method:   http.MethodGet,
 			Endpoint: endpoint.GuildAuditLogs(Snowflake(7)),
 			Ctx:      context.Background(),
 		}, nil)
@@ -167,7 +167,7 @@ func TestGuildAuditLogs(t *testing.T) {
 		builder := &guildAuditLogsBuilder{}
 		builder.r.itemFactory = auditLogFactory
 		builder.r.IgnoreCache().setup(client, &httd.Request{
-			Method:   httd.MethodGet,
+			Method:   http.MethodGet,
 			Endpoint: endpoint.GuildAuditLogs(Snowflake(7)),
 			Ctx:      context.Background(),
 		}, nil)

--- a/channel.go
+++ b/channel.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
+	"net/http"
 	"strconv"
 	"strings"
 	"sync"
@@ -379,7 +380,7 @@ func (c channelQueryBuilder) UpdateBuilder() UpdateChannelBuilder {
 	}
 	builder.r.flags = c.flags
 	builder.r.setup(c.client.req, &httd.Request{
-		Method:      httd.MethodPatch,
+		Method:      http.MethodPatch,
 		Ctx:         c.ctx,
 		Endpoint:    endpoint.Channel(c.cid),
 		ContentType: httd.ContentTypeJSON,
@@ -407,7 +408,7 @@ func (c channelQueryBuilder) Delete() (channel *Channel, err error) {
 	}
 
 	r := c.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodDelete,
+		Method:   http.MethodDelete,
 		Endpoint: endpoint.Channel(c.cid),
 		Ctx:      context.Background(),
 	}, c.flags)
@@ -429,7 +430,7 @@ func (c channelQueryBuilder) Delete() (channel *Channel, err error) {
 //  Comment                 -
 func (c channelQueryBuilder) TriggerTypingIndicator() (err error) {
 	r := c.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodPost,
+		Method:   http.MethodPost,
 		Endpoint: endpoint.ChannelTyping(c.cid),
 		Ctx:      c.ctx,
 	}, c.flags)
@@ -462,7 +463,7 @@ func (c channelQueryBuilder) UpdatePermissions(overwriteID Snowflake, params *Up
 	}
 
 	r := c.client.newRESTRequest(&httd.Request{
-		Method:      httd.MethodPut,
+		Method:      http.MethodPut,
 		Ctx:         c.ctx,
 		Endpoint:    endpoint.ChannelPermission(c.cid, overwriteID),
 		ContentType: httd.ContentTypeJSON,
@@ -513,7 +514,7 @@ func (c channelQueryBuilder) CreateInvite() CreateChannelInviteBuilder {
 	}
 	builder.r.flags = c.flags
 	builder.r.setup(c.client.req, &httd.Request{
-		Method:      httd.MethodPost,
+		Method:      http.MethodPost,
 		Ctx:         c.ctx,
 		Endpoint:    endpoint.ChannelInvites(c.cid),
 		ContentType: httd.ContentTypeJSON,
@@ -539,7 +540,7 @@ func (c channelQueryBuilder) DeletePermission(overwriteID Snowflake) (err error)
 	}
 
 	r := c.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodDelete,
+		Method:   http.MethodDelete,
 		Endpoint: endpoint.ChannelPermission(c.cid, overwriteID),
 		Ctx:      c.ctx,
 	}, c.flags)
@@ -588,7 +589,7 @@ func (c channelQueryBuilder) AddDMParticipant(participant *GroupDMParticipant) e
 	}
 
 	r := c.client.newRESTRequest(&httd.Request{
-		Method:      httd.MethodPut,
+		Method:      http.MethodPut,
 		Ctx:         c.ctx,
 		Endpoint:    endpoint.ChannelRecipient(c.cid, participant.UserID),
 		Body:        participant,
@@ -614,7 +615,7 @@ func (c channelQueryBuilder) KickParticipant(userID Snowflake) (err error) {
 	}
 
 	r := c.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodDelete,
+		Method:   http.MethodDelete,
 		Endpoint: endpoint.ChannelRecipient(c.cid, userID),
 		Ctx:      c.ctx,
 	}, c.flags)
@@ -859,7 +860,7 @@ func (c channelQueryBuilder) DeleteMessages(params *DeleteMessagesParams) (err e
 	}
 
 	r := c.client.newRESTRequest(&httd.Request{
-		Method:      httd.MethodPost,
+		Method:      http.MethodPost,
 		Ctx:         c.ctx,
 		Endpoint:    endpoint.ChannelMessagesBulkDelete(c.cid),
 		ContentType: httd.ContentTypeJSON,
@@ -1018,7 +1019,7 @@ func (c channelQueryBuilder) CreateMessage(params *CreateMessageParams) (ret *Me
 	}
 
 	r := c.client.newRESTRequest(&httd.Request{
-		Method:      httd.MethodPost,
+		Method:      http.MethodPost,
 		Ctx:         c.ctx,
 		Endpoint:    "/channels/" + c.cid.String() + "/messages",
 		Body:        postBody,
@@ -1087,7 +1088,7 @@ func (c channelQueryBuilder) CreateWebhook(params *CreateWebhookParams) (ret *We
 	}
 
 	r := c.client.newRESTRequest(&httd.Request{
-		Method:      httd.MethodPost,
+		Method:      http.MethodPost,
 		Ctx:         c.ctx,
 		Endpoint:    endpoint.ChannelWebhooks(c.cid),
 		Body:        params,

--- a/emoji.go
+++ b/emoji.go
@@ -3,6 +3,7 @@ package disgord
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/andersfylling/disgord/internal/endpoint"
@@ -126,7 +127,7 @@ func (g guildEmojiQueryBuilder) UpdateBuilder() UpdateGuildEmojiBuilder {
 	}
 	builder.r.flags = g.flags
 	builder.r.setup(g.client.req, &httd.Request{
-		Method:      httd.MethodPatch,
+		Method:      http.MethodPatch,
 		Ctx:         g.ctx,
 		Endpoint:    endpoint.GuildEmoji(g.gid, g.emojiID),
 		ContentType: httd.ContentTypeJSON,
@@ -139,7 +140,7 @@ func (g guildEmojiQueryBuilder) UpdateBuilder() UpdateGuildEmojiBuilder {
 // success. Fires a Guild Emojis Update Gateway event.
 func (g guildEmojiQueryBuilder) Delete() (err error) {
 	r := g.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodDelete,
+		Method:   http.MethodDelete,
 		Endpoint: endpoint.GuildEmoji(g.gid, g.emojiID),
 		Ctx:      g.ctx,
 	}, g.flags)

--- a/gateway.go
+++ b/gateway.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/andersfylling/disgord/internal/gateway"
 	"github.com/andersfylling/disgord/internal/gateway/cmd"
@@ -221,7 +222,7 @@ func (g gatewayQueryBuilder) Dispatch(name GatewayCmdName, payload gateway.CmdPa
 func (g gatewayQueryBuilder) Get() (gateway *gateway.Gateway, err error) {
 	var body []byte
 	_, body, err = g.client.req.Do(g.ctx, &httd.Request{
-		Method:   httd.MethodGet,
+		Method:   http.MethodGet,
 		Endpoint: "/gateway",
 	})
 	if err != nil {
@@ -249,7 +250,7 @@ func (g gatewayQueryBuilder) Get() (gateway *gateway.Gateway, err error) {
 func (g gatewayQueryBuilder) GetBot() (gateway *gateway.GatewayBot, err error) {
 	var body []byte
 	_, body, err = g.client.req.Do(g.ctx, &httd.Request{
-		Method:   httd.MethodGet,
+		Method:   http.MethodGet,
 		Endpoint: "/gateway/bot",
 	})
 	if err != nil {

--- a/guild.go
+++ b/guild.go
@@ -646,7 +646,7 @@ func (c clientQueryBuilder) CreateGuild(guildName string, params *CreateGuildPar
 	params.Name = guildName
 
 	r := c.client.newRESTRequest(&httd.Request{
-		Method:      httd.MethodPost,
+		Method:      http.MethodPost,
 		Ctx:         c.ctx,
 		Endpoint:    endpoint.Guilds(),
 		Body:        params,
@@ -778,7 +778,7 @@ func (g guildQueryBuilder) UpdateBuilder() UpdateGuildBuilder {
 		return &Guild{}
 	}
 	builder.r.setup(g.client.req, &httd.Request{
-		Method:      httd.MethodPatch,
+		Method:      http.MethodPatch,
 		Ctx:         g.ctx,
 		Endpoint:    endpoint.Guild(g.gid),
 		ContentType: httd.ContentTypeJSON,
@@ -791,7 +791,7 @@ func (g guildQueryBuilder) UpdateBuilder() UpdateGuildBuilder {
 // Delete is used to delete a guild.
 func (g guildQueryBuilder) Delete() error {
 	r := g.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodDelete,
+		Method:   http.MethodDelete,
 		Endpoint: endpoint.Guild(g.gid),
 		Ctx:      g.ctx,
 	}, g.flags)
@@ -836,7 +836,7 @@ func (g guildQueryBuilder) CreateChannel(name string, params *CreateGuildChannel
 	}
 
 	r := g.client.newRESTRequest(&httd.Request{
-		Method:      httd.MethodPost,
+		Method:      http.MethodPost,
 		Ctx:         g.ctx,
 		Endpoint:    endpoint.GuildChannels(g.gid),
 		Body:        params,
@@ -862,7 +862,7 @@ func (g guildQueryBuilder) UpdateChannelPositions(params []UpdateGuildChannelPos
 		}
 	}
 	r := g.client.newRESTRequest(&httd.Request{
-		Method:      httd.MethodPatch,
+		Method:      http.MethodPatch,
 		Ctx:         g.ctx,
 		Endpoint:    endpoint.GuildChannels(g.gid),
 		Body:        params,
@@ -954,7 +954,7 @@ func (g guildQueryBuilder) CreateMember(userID Snowflake, accessToken string, pa
 	}
 
 	r := g.client.newRESTRequest(&httd.Request{
-		Method:      httd.MethodPut,
+		Method:      http.MethodPut,
 		Ctx:         g.ctx,
 		Endpoint:    endpoint.GuildMember(g.gid, userID),
 		Body:        params,
@@ -991,7 +991,7 @@ func (g guildQueryBuilder) SetCurrentUserNick(nick string) (newNick string, err 
 	}
 
 	r := g.client.newRESTRequest(&httd.Request{
-		Method:      httd.MethodPatch,
+		Method:      http.MethodPatch,
 		Ctx:         g.ctx,
 		Endpoint:    endpoint.GuildMembersMeNick(g.gid),
 		Body:        params,
@@ -1045,7 +1045,7 @@ func (g guildQueryBuilder) GetBan(userID Snowflake) (*Ban, error) {
 // Returns a 204 empty response on success. Fires a Guild Ban Remove Gateway event.
 func (g guildQueryBuilder) UnbanUser(userID Snowflake, reason string) error {
 	r := g.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodDelete,
+		Method:   http.MethodDelete,
 		Endpoint: endpoint.GuildBan(g.gid, userID),
 		Reason:   reason,
 		Ctx:      g.ctx,
@@ -1086,7 +1086,7 @@ type CreateGuildRoleParams struct {
 // Returns the new role object on success. Fires a Guild Role Create Gateway event.
 func (g guildQueryBuilder) CreateRole(params *CreateGuildRoleParams) (*Role, error) {
 	r := g.client.newRESTRequest(&httd.Request{
-		Method:      httd.MethodPost,
+		Method:      http.MethodPost,
 		Ctx:         g.ctx,
 		Endpoint:    endpoint.GuildRoles(g.gid),
 		Body:        params,
@@ -1113,7 +1113,7 @@ func (g guildQueryBuilder) UpdateRolePositions(params []UpdateGuildRolePositions
 	}
 
 	r := g.client.newRESTRequest(&httd.Request{
-		Method:      httd.MethodPatch,
+		Method:      http.MethodPatch,
 		Ctx:         g.ctx,
 		Endpoint:    endpoint.GuildRoles(g.gid),
 		Body:        params,
@@ -1169,7 +1169,7 @@ func (g guildQueryBuilder) PruneMembers(days int, reason string) (err error) {
 	}
 
 	r := g.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodPost,
+		Method:   http.MethodPost,
 		Endpoint: endpoint.GuildPrune(g.gid) + params.URLQueryString(),
 		Ctx:      g.ctx,
 		Reason:   reason,
@@ -1229,7 +1229,7 @@ func (g guildQueryBuilder) GetIntegrations() ([]*Integration, error) {
 // Fires a Guild Integrations Update Gateway event.
 func (g guildQueryBuilder) CreateIntegration(params *CreateGuildIntegrationParams) error {
 	r := g.client.newRESTRequest(&httd.Request{
-		Method:      httd.MethodPost,
+		Method:      http.MethodPost,
 		Ctx:         g.ctx,
 		Endpoint:    endpoint.GuildIntegrations(g.gid),
 		Body:        params,
@@ -1245,7 +1245,7 @@ func (g guildQueryBuilder) CreateIntegration(params *CreateGuildIntegrationParam
 // Fires a Guild Integrations Update Gateway event.
 func (g guildQueryBuilder) UpdateIntegration(integrationID Snowflake, params *UpdateGuildIntegrationParams) error {
 	r := g.client.newRESTRequest(&httd.Request{
-		Method:      httd.MethodPatch,
+		Method:      http.MethodPatch,
 		Ctx:         g.ctx,
 		Endpoint:    endpoint.GuildIntegration(g.gid, integrationID),
 		Body:        params,
@@ -1261,7 +1261,7 @@ func (g guildQueryBuilder) UpdateIntegration(integrationID Snowflake, params *Up
 // Fires a Guild Integrations Update Gateway event.
 func (g guildQueryBuilder) DeleteIntegration(integrationID Snowflake) error {
 	r := g.client.newRESTRequest(&httd.Request{
-		Method:      httd.MethodDelete,
+		Method:      http.MethodDelete,
 		Ctx:         g.ctx,
 		Endpoint:    endpoint.GuildIntegration(g.gid, integrationID),
 		ContentType: httd.ContentTypeJSON,
@@ -1275,7 +1275,7 @@ func (g guildQueryBuilder) DeleteIntegration(integrationID Snowflake) error {
 // Returns a 204 empty response on success.
 func (g guildQueryBuilder) SyncIntegration(integrationID Snowflake) error {
 	r := g.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodPost,
+		Method:   http.MethodPost,
 		Endpoint: endpoint.GuildIntegrationSync(g.gid, integrationID),
 		Ctx:      g.ctx,
 	}, g.flags)
@@ -1306,7 +1306,7 @@ func (g guildQueryBuilder) UpdateEmbedBuilder() UpdateGuildEmbedBuilder {
 	}
 	builder.r.flags = g.flags
 	builder.r.setup(g.client.req, &httd.Request{
-		Method:      httd.MethodPatch,
+		Method:      http.MethodPatch,
 		Ctx:         g.ctx,
 		Endpoint:    endpoint.GuildEmbed(g.gid),
 		ContentType: httd.ContentTypeJSON,
@@ -1337,7 +1337,7 @@ func (g guildQueryBuilder) GetAuditLogs() GuildAuditLogsBuilder {
 	builder.r.flags = g.flags
 	builder.r.IgnoreCache().setup(g.client.req, &httd.Request{
 		Ctx:      g.ctx,
-		Method:   httd.MethodGet,
+		Method:   http.MethodGet,
 		Endpoint: endpoint.GuildAuditLogs(g.gid),
 	}, nil)
 
@@ -1399,7 +1399,7 @@ func (g guildQueryBuilder) CreateEmoji(params *CreateGuildEmojiParams) (*Emoji, 
 	}
 
 	r := g.client.newRESTRequest(&httd.Request{
-		Method:      httd.MethodPost,
+		Method:      http.MethodPost,
 		Ctx:         g.ctx,
 		Endpoint:    endpoint.GuildEmojis(g.gid),
 		ContentType: httd.ContentTypeJSON,

--- a/internal/httd/client.go
+++ b/internal/httd/client.go
@@ -242,7 +242,7 @@ func (c *Client) Do(ctx context.Context, r *Request) (resp *http.Response, body 
 	}
 
 	// create http request
-	req, err := http.NewRequestWithContext(ctx, r.Method.String(), c.url+r.Endpoint, r.bodyReader)
+	req, err := http.NewRequestWithContext(ctx, r.Method, c.url+r.Endpoint, r.bodyReader)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/httd/header.go
+++ b/internal/httd/header.go
@@ -105,8 +105,8 @@ func NormalizeDiscordHeader(statusCode int, header http.Header, body []byte) (h 
 			timestamp = now
 		}
 
-		reset := timestamp.Add(time.Duration(delay) * time.Millisecond)
-		ms := reset.UnixNano() / int64(time.Millisecond)
+		resetTime := timestamp.Add(time.Duration(delay) * time.Millisecond)
+		ms := resetTime.UnixNano() / int64(time.Millisecond)
 		header.Set(XRateLimitReset, strconv.FormatInt(ms, 10))
 	}
 

--- a/internal/httd/request.go
+++ b/internal/httd/request.go
@@ -2,27 +2,10 @@ package httd
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"regexp"
 	"strings"
-)
-
-type httpMethod string
-
-var _ fmt.Stringer = (*httpMethod)(nil)
-
-func (method httpMethod) String() string {
-	return string(method)
-}
-
-const (
-	MethodGet    httpMethod = http.MethodGet
-	MethodDelete httpMethod = http.MethodDelete
-	MethodPost   httpMethod = http.MethodPost
-	MethodPatch  httpMethod = http.MethodPatch
-	MethodPut    httpMethod = http.MethodPut
 )
 
 var regexpURLSnowflakes = regexp.MustCompile(RegexpURLSnowflakes)
@@ -34,7 +17,7 @@ var regexpURLReactionEmojiSegment = regexp.MustCompile(`\/reactions\/` + RegexpE
 type Request struct {
 	Ctx context.Context
 
-	Method      httpMethod
+	Method      string
 	Endpoint    string
 	Body        interface{} // will automatically marshal to JSON if the ContentType is httd.ContentTypeJSON
 	ContentType string
@@ -48,7 +31,7 @@ type Request struct {
 
 func (r *Request) PopulateMissing() {
 	if r.Method == "" {
-		r.Method = MethodGet
+		r.Method = http.MethodGet
 	}
 	if r.Ctx == nil {
 		r.Ctx = context.Background()
@@ -94,8 +77,8 @@ func (r *Request) HashEndpoint() string {
 			// corner case for urls with emojis
 			suffix := buffer[len(reactionPrefixMatch[0]):]
 			until := len(suffix)
-			for i, rune := range suffix {
-				if rune == '/' {
+			for i, runeVal := range suffix {
+				if runeVal == '/' {
 					until = i
 					break
 				}
@@ -108,5 +91,5 @@ func (r *Request) HashEndpoint() string {
 	if strings.HasSuffix(buffer, "/") {
 		buffer = buffer[:len(buffer)-1]
 	}
-	return r.Method.String() + ":" + buffer
+	return r.Method + ":" + buffer
 }

--- a/invite.go
+++ b/invite.go
@@ -2,6 +2,7 @@ package disgord
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/andersfylling/disgord/internal/endpoint"
 	"github.com/andersfylling/disgord/internal/httd"
@@ -156,7 +157,7 @@ func (i inviteQueryBuilder) Get(withMemberCount bool) (invite *Invite, err error
 //  Comment                 -
 func (i inviteQueryBuilder) Delete() (deleted *Invite, err error) {
 	r := i.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodDelete,
+		Method:   http.MethodDelete,
 		Endpoint: endpoint.Invite(i.inviteCode),
 		Ctx:      i.ctx,
 	}, i.flags)

--- a/member.go
+++ b/member.go
@@ -3,6 +3,7 @@ package disgord
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	"github.com/andersfylling/disgord/internal/endpoint"
 	"github.com/andersfylling/disgord/internal/httd"
@@ -81,7 +82,7 @@ func (g guildMemberQueryBuilder) UpdateBuilder() UpdateGuildMemberBuilder {
 	}
 	builder.r.flags = g.flags
 	builder.r.setup(g.client.req, &httd.Request{
-		Method:      httd.MethodPatch,
+		Method:      http.MethodPatch,
 		Ctx:         g.ctx,
 		Endpoint:    endpoint.GuildMember(g.gid, g.uid),
 		ContentType: httd.ContentTypeJSON,
@@ -95,7 +96,7 @@ func (g guildMemberQueryBuilder) UpdateBuilder() UpdateGuildMemberBuilder {
 // Returns a 204 empty response on success. Fires a Guild Member Update Gateway event.
 func (g guildMemberQueryBuilder) AddRole(roleID Snowflake) error {
 	r := g.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodPut,
+		Method:   http.MethodPut,
 		Endpoint: endpoint.GuildMemberRole(g.gid, g.uid, roleID),
 		Ctx:      g.ctx,
 	}, g.flags)
@@ -108,7 +109,7 @@ func (g guildMemberQueryBuilder) AddRole(roleID Snowflake) error {
 // Returns a 204 empty response on success. Fires a Guild Member Update Gateway event.
 func (g guildMemberQueryBuilder) RemoveRole(roleID Snowflake) error {
 	r := g.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodDelete,
+		Method:   http.MethodDelete,
 		Endpoint: endpoint.GuildMemberRole(g.gid, g.uid, roleID),
 		Ctx:      g.ctx,
 	}, g.flags)
@@ -121,7 +122,7 @@ func (g guildMemberQueryBuilder) RemoveRole(roleID Snowflake) error {
 // Returns a 204 empty response on success. Fires a Guild Member Remove Gateway event.
 func (g guildMemberQueryBuilder) Kick(reason string) error {
 	r := g.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodDelete,
+		Method:   http.MethodDelete,
 		Endpoint: endpoint.GuildMember(g.gid, g.uid),
 		Reason:   reason,
 		Ctx:      g.ctx,
@@ -142,7 +143,7 @@ func (g guildMemberQueryBuilder) Ban(params *BanMemberParams) (err error) {
 	}
 
 	r := g.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodPut,
+		Method:   http.MethodPut,
 		Endpoint: endpoint.GuildBan(g.gid, g.uid) + params.URLQueryString(),
 		Ctx:      g.ctx,
 		Reason:   params.Reason,

--- a/message.go
+++ b/message.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/andersfylling/disgord/internal/endpoint"
 	"github.com/andersfylling/disgord/internal/httd"
@@ -428,7 +429,7 @@ func (m messageQueryBuilder) UpdateBuilder() UpdateMessageBuilder {
 	builder.r.addPrereq(m.cid.IsZero(), "channelID must be set to get channel messages")
 	builder.r.addPrereq(m.mid.IsZero(), "msgID must be set to edit the message")
 	builder.r.setup(m.client.req, &httd.Request{
-		Method:      httd.MethodPatch,
+		Method:      http.MethodPatch,
 		Ctx:         m.ctx,
 		Endpoint:    "/channels/" + m.cid.String() + "/messages/" + m.mid.String(),
 		ContentType: httd.ContentTypeJSON,
@@ -456,7 +457,7 @@ func (m messageQueryBuilder) Delete() (err error) {
 	}
 
 	r := m.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodDelete,
+		Method:   http.MethodDelete,
 		Endpoint: endpoint.ChannelMessage(m.cid, m.mid),
 		Ctx:      m.ctx,
 	}, m.flags)
@@ -474,7 +475,7 @@ func (m messageQueryBuilder) Delete() (err error) {
 //  Comment                 -
 func (m messageQueryBuilder) Pin() (err error) {
 	r := m.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodPut,
+		Method:   http.MethodPut,
 		Endpoint: endpoint.ChannelPin(m.cid, m.mid),
 		Ctx:      m.ctx,
 	}, m.flags)
@@ -499,7 +500,7 @@ func (m messageQueryBuilder) Unpin() (err error) {
 	}
 
 	r := m.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodDelete,
+		Method:   http.MethodDelete,
 		Endpoint: endpoint.ChannelPin(m.cid, m.mid),
 		Ctx:      m.ctx,
 	}, m.flags)
@@ -523,7 +524,7 @@ func (m messageQueryBuilder) CrossPost() (*Message, error) {
 	}
 
 	r := m.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodPost,
+		Method:   http.MethodPost,
 		Endpoint: endpoint.ChannelMessageCrossPost(m.cid, m.mid),
 		Ctx:      m.ctx,
 	}, m.flags)
@@ -554,7 +555,7 @@ func (m messageQueryBuilder) DeleteAllReactions() error {
 	}
 
 	r := m.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodDelete,
+		Method:   http.MethodDelete,
 		Endpoint: endpoint.ChannelMessageReactions(m.cid, m.mid),
 		Ctx:      m.ctx,
 	}, m.flags)

--- a/reaction.go
+++ b/reaction.go
@@ -3,6 +3,7 @@ package disgord
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	"github.com/andersfylling/disgord/internal/endpoint"
 	"github.com/andersfylling/disgord/internal/httd"
@@ -117,7 +118,7 @@ func (r reactionQueryBuilder) Create() error {
 	}
 
 	req := r.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodPut,
+		Method:   http.MethodPut,
 		Endpoint: endpoint.ChannelMessageReactionMe(r.cid, r.mid, emojiCode),
 		Ctx:      r.ctx,
 	}, r.flags)
@@ -150,7 +151,7 @@ func (r reactionQueryBuilder) DeleteOwn() error {
 	}
 
 	req := r.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodDelete,
+		Method:   http.MethodDelete,
 		Endpoint: endpoint.ChannelMessageReactionMe(r.cid, r.mid, emojiCode),
 		Ctx:      r.ctx,
 	}, r.flags)
@@ -186,7 +187,7 @@ func (r reactionQueryBuilder) DeleteUser(userID Snowflake) error {
 	}
 
 	req := r.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodDelete,
+		Method:   http.MethodDelete,
 		Endpoint: endpoint.ChannelMessageReactionUser(r.cid, r.mid, emojiCode, userID),
 		Ctx:      r.ctx,
 	}, r.flags)

--- a/rest.go
+++ b/rest.go
@@ -94,7 +94,7 @@ func (r *rest) init() {
 	if r.conf != nil {
 		r.conf.PopulateMissing()
 	}
-	r.httpMethod = r.conf.Method.String()
+	r.httpMethod = r.conf.Method
 	r.doRequest = r.stepDoRequest
 }
 

--- a/role.go
+++ b/role.go
@@ -3,6 +3,7 @@ package disgord
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sort"
 
 	"github.com/andersfylling/disgord/internal/endpoint"
@@ -113,7 +114,7 @@ func (g guildRoleQueryBuilder) UpdateBuilder() UpdateGuildRoleBuilder {
 	}
 	builder.r.flags = g.flags
 	builder.r.IgnoreCache().setup(g.client.req, &httd.Request{
-		Method:      httd.MethodPatch,
+		Method:      http.MethodPatch,
 		Ctx:         g.ctx,
 		Endpoint:    endpoint.GuildRole(g.gid, g.roleID),
 		ContentType: httd.ContentTypeJSON,
@@ -126,7 +127,7 @@ func (g guildRoleQueryBuilder) UpdateBuilder() UpdateGuildRoleBuilder {
 // Returns a 204 empty response on success. Fires a Guild Role Delete Gateway event.
 func (g guildRoleQueryBuilder) Delete() error {
 	r := g.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodDelete,
+		Method:   http.MethodDelete,
 		Endpoint: endpoint.GuildRole(g.gid, g.roleID),
 		Ctx:      g.ctx,
 	}, g.flags)

--- a/user.go
+++ b/user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/andersfylling/disgord/internal/endpoint"
@@ -370,7 +371,7 @@ func (c userQueryBuilder) Get() (*User, error) {
 //  Comment                 -
 func (c userQueryBuilder) CreateDM() (ret *Channel, err error) {
 	r := c.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodPost,
+		Method:   http.MethodPost,
 		Ctx:      c.ctx,
 		Endpoint: endpoint.UserMeChannels(),
 		Body: &struct {
@@ -473,7 +474,7 @@ func (c currentUserQueryBuilder) UpdateBuilder() UpdateCurrentUserBuilder {
 	builder.r.itemFactory = userFactory // TODO: peak cached user
 	builder.r.flags = c.flags
 	builder.r.setup(c.client.req, &httd.Request{
-		Method:      httd.MethodPatch,
+		Method:      http.MethodPatch,
 		Ctx:         c.ctx,
 		Endpoint:    endpoint.UserMe(),
 		ContentType: httd.ContentTypeJSON,
@@ -540,7 +541,7 @@ type CreateGroupDMParams struct {
 //  Comment                 -
 func (c currentUserQueryBuilder) LeaveGuild(id Snowflake) (err error) {
 	r := c.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodDelete,
+		Method:   http.MethodDelete,
 		Endpoint: endpoint.UserMeGuild(id),
 		Ctx:      c.ctx,
 	}, c.flags)
@@ -559,7 +560,7 @@ func (c currentUserQueryBuilder) LeaveGuild(id Snowflake) (err error) {
 //  Comment                 -
 func (c currentUserQueryBuilder) CreateGroupDM(params *CreateGroupDMParams) (ret *Channel, err error) {
 	r := c.client.newRESTRequest(&httd.Request{
-		Method:      httd.MethodPost,
+		Method:      http.MethodPost,
 		Ctx:         c.ctx,
 		Endpoint:    endpoint.UserMeChannels(),
 		Body:        params,

--- a/webhook.go
+++ b/webhook.go
@@ -3,6 +3,7 @@ package disgord
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	"github.com/andersfylling/disgord/internal/endpoint"
 	"github.com/andersfylling/disgord/internal/httd"
@@ -110,7 +111,7 @@ func (w webhookQueryBuilder) UpdateBuilder() UpdateWebhookBuilder {
 	builder.r.flags = w.flags
 	builder.r.addPrereq(w.webhookID.IsZero(), "given webhook ID was not set, there is nothing to modify")
 	builder.r.setup(w.client.req, &httd.Request{
-		Method:      httd.MethodPatch,
+		Method:      http.MethodPatch,
 		Ctx:         w.ctx,
 		Endpoint:    endpoint.Webhook(w.webhookID),
 		ContentType: httd.ContentTypeJSON,
@@ -250,7 +251,7 @@ func (w webhookWithTokenQueryBuilder) UpdateBuilder() UpdateWebhookBuilder {
 	builder.r.addPrereq(w.webhookID.IsZero(), "given webhook ID was not set, there is nothing to modify")
 	builder.r.addPrereq(w.token == "", "given webhook token was not set")
 	builder.r.setup(w.client.req, &httd.Request{
-		Method:      httd.MethodPatch,
+		Method:      http.MethodPatch,
 		Ctx:         w.ctx,
 		Endpoint:    endpoint.WebhookToken(w.webhookID, w.token),
 		ContentType: httd.ContentTypeJSON,
@@ -274,7 +275,7 @@ func (w webhookWithTokenQueryBuilder) Delete() error {
 	}
 
 	r := w.client.newRESTRequest(&httd.Request{
-		Method:   httd.MethodDelete,
+		Method:   http.MethodDelete,
 		Endpoint: e,
 		Ctx:      w.ctx,
 	}, w.flags)
@@ -317,7 +318,7 @@ func (w webhookWithTokenQueryBuilder) Execute(params *ExecuteWebhookParams, wait
 
 	urlparams := &execWebhookParams{wait}
 	r := w.client.newRESTRequest(&httd.Request{
-		Method:      httd.MethodPost,
+		Method:      http.MethodPost,
 		Ctx:         w.ctx,
 		Endpoint:    endpoint.WebhookToken(w.webhookID, w.token) + URLSuffix + urlparams.URLQueryString(),
 		Body:        params,


### PR DESCRIPTION
Removed the custom http method type. While I like the idea of restraining the value, it seems like an annoyance if discord adds methods i haven't covered yet.

Invalid use should be ease to spot in a PR / test anyways.