### PR TITLE
feat!:rename interaction callback consts

### DIFF
--- a/interaction.go
+++ b/interaction.go
@@ -29,13 +29,13 @@ type InteractionCallbackType = int
 
 const (
 	_ InteractionCallbackType = iota
-	Pong
+	InteractionCallbackPong
 	_
 	_
-	ChannelMessageWithSource
-	DeferredChannelMessageWithSource
-	DeferredUpdateMessage
-	UpdateMessage
+	InteractionCallbackChannelMessageWithSource
+	InteractionCallbackDeferredChannelMessageWithSource
+	InteractionCallbackDeferredUpdateMessage
+	InteractionCallbackUpdateMessage
 )
 
 // ApplicationCommandInteractionDataResolved ..


### PR DESCRIPTION
I noticed this doesn't conform with other discord consts, also disgord.Pong might not provide much detail and these simplistic names may cause collision in the future.