### PR TITLE
feat: shorter struct names for REST API

### DIFF
--- a/auditlog_test.go
+++ b/auditlog_test.go
@@ -72,7 +72,7 @@ func TestAuditLog_InterfaceImplementations(t *testing.T) {
 	})
 }
 
-func TestAuditLogParams(t *testing.T) {
+func TestAuditLog(t *testing.T) {
 	params := &guildAuditLogsBuilder{}
 	params.r.setup(nil, nil, nil)
 	var wants string

--- a/cache.go
+++ b/cache.go
@@ -753,13 +753,13 @@ func (c *BasicCache) GuildRoleDelete(data []byte) (evt *GuildRoleDelete, err err
 // func (c *BasicCache) GetMessage(channelID, messageID Snowflake) (*Message, error) {
 // 	return nil, nil
 // }
-// func (c *BasicCache) GetCurrentUserGuilds(p *GetCurrentUserGuildsParams) ([]*PartialGuild, error) {
+// func (c *BasicCache) GetCurrentUserGuilds(p *GetCurrentUserGuilds) ([]*PartialGuild, error) {
 // 	return nil, nil
 // }
-// func (c *BasicCache) GetMessages(channel Snowflake, p *GetMessagesParams) ([]*Message, error) {
+// func (c *BasicCache) GetMessages(channel Snowflake, p *GetMessages) ([]*Message, error) {
 // 	return nil, nil
 // }
-// func (c *BasicCache) GetMembers(guildID Snowflake, p *GetMembersParams) ([]*Member, error) {
+// func (c *BasicCache) GetMembers(guildID Snowflake, p *GetMembers) ([]*Member, error) {
 // 	return nil, nil
 // }
 

--- a/cache_gen.go
+++ b/cache_gen.go
@@ -21,7 +21,7 @@ type CacheGetter interface {
 	// REST API
 
 	// GetGuildAuditLogs(guildID Snowflake) *guildAuditLogsBuilder // TODO
-	GetMessages(channelID Snowflake, params *GetMessagesParams) ([]*Message, error)
+	GetMessages(channelID Snowflake, params *GetMessages) ([]*Message, error)
 	GetMessage(channelID, messageID Snowflake) (ret *Message, err error)
 	//GetUsersWhoReacted(channelID, messageID Snowflake, emoji interface{}, params URLQueryStringer) (reactors []*User, err error)
 	//GetPinnedMessages(channelID Snowflake) (ret []*Message, err error)
@@ -32,7 +32,7 @@ type CacheGetter interface {
 	GetGuild(id Snowflake) (*Guild, error)
 	GetGuildChannels(id Snowflake) ([]*Channel, error)
 	GetMember(guildID, userID Snowflake) (*Member, error)
-	GetMembers(guildID Snowflake, params *GetMembersParams) ([]*Member, error)
+	GetMembers(guildID Snowflake, params *GetMembers) ([]*Member, error)
 	//GetGuildBans(id Snowflake) ([]*Ban, error)
 	//GetGuildBan(guildID, userID Snowflake) (*Ban, error)
 	GetGuildRoles(guildID Snowflake) ([]*Role, error)
@@ -45,7 +45,7 @@ type CacheGetter interface {
 	//GetInvite(inviteCode string, params URLQueryStringer) (*Invite, error)
 	GetCurrentUser() (*User, error)
 	GetUser(id Snowflake) (*User, error)
-	GetCurrentUserGuilds(params *GetCurrentUserGuildsParams) (ret []*Guild, err error)
+	GetCurrentUserGuilds(params *GetCurrentUserGuilds) (ret []*Guild, err error)
 	//GetUserDMs() (ret []*Channel, err error)
 	//GetUserConnections() (ret []*UserConnection, err error)
 	//GetVoiceRegions() ([]*VoiceRegion, error)
@@ -529,12 +529,12 @@ func (c *CacheNop) GetMember(guildID, userID Snowflake) (*Member, error) { retur
 func (c *CacheNop) GetGuildRoles(guildID Snowflake) ([]*Role, error)     { return nil, CacheMissErr }
 func (c *CacheNop) GetCurrentUser() (*User, error)                       { return nil, CacheMissErr }
 func (c *CacheNop) GetUser(id Snowflake) (*User, error)                  { return nil, CacheMissErr }
-func (c *CacheNop) GetCurrentUserGuilds(p *GetCurrentUserGuildsParams) ([]*Guild, error) {
+func (c *CacheNop) GetCurrentUserGuilds(p *GetCurrentUserGuilds) ([]*Guild, error) {
 	return nil, CacheMissErr
 }
-func (c *CacheNop) GetMessages(channel Snowflake, p *GetMessagesParams) ([]*Message, error) {
+func (c *CacheNop) GetMessages(channel Snowflake, p *GetMessages) ([]*Message, error) {
 	return nil, CacheMissErr
 }
-func (c *CacheNop) GetMembers(guildID Snowflake, p *GetMembersParams) ([]*Member, error) {
+func (c *CacheNop) GetMembers(guildID Snowflake, p *GetMembers) ([]*Member, error) {
 	return nil, CacheMissErr
 }

--- a/channel.go
+++ b/channel.go
@@ -197,7 +197,7 @@ func (c *Channel) SendMsgString(ctx context.Context, s Session, content string) 
 		err = newErrorMissingSnowflake("snowflake ID not set for channel")
 		return
 	}
-	params := &CreateMessageParams{
+	params := &CreateMessage{
 		Content: content,
 	}
 
@@ -216,7 +216,7 @@ func (c *Channel) SendMsg(ctx context.Context, s Session, message *Message) (msg
 		return nil, errors.New("nonce can not be longer than 25 characters")
 	}
 
-	params := &CreateMessageParams{
+	params := &CreateMessage{
 		Content:          message.Content,
 		Nonce:            nonce, // THIS IS A STRING. NOT A SNOWFLAKE! DONT TOUCH!
 		Tts:              message.Tts,
@@ -271,7 +271,7 @@ type ChannelQueryBuilder interface {
 	// UpdatePermissions Edit the channel permission overwrites for a user or role in a channel. Only usable
 	// for guild Channels. Requires the 'MANAGE_ROLES' permission. Returns a 204 empty response on success.
 	// For more information about permissions, see permissions.
-	UpdatePermissions(overwriteID Snowflake, params *UpdateChannelPermissionsParams) error
+	UpdatePermissions(overwriteID Snowflake, params *UpdateChannelPermissions) error
 
 	// GetInvites Returns a list of invite objects (with invite metadata) for the channel. Only usable for
 	// guild Channels. Requires the 'MANAGE_CHANNELS' permission.
@@ -304,24 +304,24 @@ type ChannelQueryBuilder interface {
 	// Message Delete Gateway events.Any message IDs given that do not exist or are invalid will count towards
 	// the minimum and maximum message count (currently 2 and 100 respectively). Additionally, duplicated IDs
 	// will only be counted once.
-	DeleteMessages(params *DeleteMessagesParams) error
+	DeleteMessages(params *DeleteMessages) error
 
 	// GetMessages Returns the messages for a channel. If operating on a guild channel, this endpoint requires
 	// the 'VIEW_CHANNEL' permission to be present on the current user. If the current user is missing
 	// the 'READ_MESSAGE_HISTORY' permission in the channel then this will return no messages
 	// (since they cannot read the message history). Returns an array of message objects on success.
-	GetMessages(params *GetMessagesParams) ([]*Message, error)
+	GetMessages(params *GetMessages) ([]*Message, error)
 
 	// CreateMessage Post a message to a guild text or DM channel. If operating on a guild channel, this
 	// endpoint requires the 'SEND_MESSAGES' permission to be present on the current user. If the tts field is set to true,
 	// the SEND_TTS_MESSAGES permission is required for the message to be spoken. Returns a message object. Fires a
 	// Message Create Gateway event. See message formatting for more information on how to properly format messages.
 	// The maximum request size when sending a message is 8MB.
-	CreateMessage(params *CreateMessageParams) (*Message, error)
+	CreateMessage(params *CreateMessage) (*Message, error)
 
 	// CreateWebhook Create a new webhook. Requires the 'MANAGE_WEBHOOKS' permission.
 	// Returns a webhook object on success.
-	CreateWebhook(params *CreateWebhookParams) (ret *Webhook, err error)
+	CreateWebhook(params *CreateWebhook) (ret *Webhook, err error)
 
 	// GetWebhooks Returns a list of channel webhook objects. Requires the 'MANAGE_WEBHOOKS' permission.
 	GetWebhooks() (ret []*Webhook, err error)
@@ -329,9 +329,9 @@ type ChannelQueryBuilder interface {
 	Message(id Snowflake) MessageQueryBuilder
 
 	// CreateThread Create a thread in a channel from a message.
-	CreateThread(messageID Snowflake, params *CreateThreadParams) (*Channel, error)
+	CreateThread(messageID Snowflake, params *CreateThread) (*Channel, error)
 	// CreateThreadNoMessage Create a thread that is not connected to an existing message.
-	CreateThreadNoMessage(params *CreateThreadParamsNoMessage) (*Channel, error)
+	CreateThreadNoMessage(params *CreateThreadNoMessage) (*Channel, error)
 	// Adds the current user to a thread. Also requires the thread is not archived.
 	// Returns a 204 empty response on success.
 	JoinThread() error
@@ -356,13 +356,13 @@ type ChannelQueryBuilder interface {
 	// threads of type GUILD_PUBLIC_THREAD. When called on a GUILD_NEWS channel returns threads of type
 	// GUILD_NEWS_THREAD. Threads are ordered by archive_timestamp, in descending order. Requires the READ_MESSAGE_HISTORY
 	// permission.
-	GetPublicArchivedThreads(params *GetThreadsParams) (*ResponseBodyThreads, error)
+	GetPublicArchivedThreads(params *GetThreads) (*ResponseBodyThreads, error)
 	// Returns archived threads in the channel that are of type GUILD_PRIVATE_THREAD. Threads are ordered by
 	// archive_timestamp, in descending order. Requires both the READ_MESSAGE_HISTORY and MANAGE_THREADS permissions.
-	GetPrivateArchivedThreads(params *GetThreadsParams) (*ResponseBodyThreads, error)
+	GetPrivateArchivedThreads(params *GetThreads) (*ResponseBodyThreads, error)
 	// Returns archived threads in the channel that are of type GUILD_PRIVATE_THREAD, and the user has joined.
 	// Threads are ordered by their id, in descending order. Requires the READ_MESSAGE_HISTORY permission.
-	GetJoinedPrivateArchivedThreads(params *GetThreadsParams) (*ResponseBodyThreads, error)
+	GetJoinedPrivateArchivedThreads(params *GetThreads) (*ResponseBodyThreads, error)
 }
 
 type channelQueryBuilder struct {
@@ -488,8 +488,8 @@ func (c channelQueryBuilder) TriggerTypingIndicator() (err error) {
 	return err
 }
 
-// UpdateChannelPermissionsParams https://discord.com/developers/docs/resources/channel#edit-channel-permissions-json-params
-type UpdateChannelPermissionsParams struct {
+// UpdateChannelPermissions https://discord.com/developers/docs/resources/channel#edit-channel-permissions-json-params
+type UpdateChannelPermissions struct {
 	Allow PermissionBit `json:"allow"` // the bitwise value of all allowed permissions
 	Deny  PermissionBit `json:"deny"`  // the bitwise value of all disallowed permissions
 	Type  uint          `json:"type"`  // 0=role, 1=member
@@ -503,7 +503,7 @@ type UpdateChannelPermissionsParams struct {
 //  Discord documentation   https://discord.com/developers/docs/resources/channel#edit-channel-permissions
 //  Reviewed                2018-06-07
 //  Comment                 -
-func (c channelQueryBuilder) UpdatePermissions(overwriteID Snowflake, params *UpdateChannelPermissionsParams) (err error) {
+func (c channelQueryBuilder) UpdatePermissions(overwriteID Snowflake, params *UpdateChannelPermissions) (err error) {
 	if c.cid.IsZero() {
 		return errors.New("channelID must be set to target the correct channel")
 	}
@@ -673,16 +673,16 @@ func (c channelQueryBuilder) KickParticipant(userID Snowflake) (err error) {
 	return err
 }
 
-// GetMessagesParams https://discord.com/developers/docs/resources/channel#get-channel-messages-query-string-params
+// GetMessages https://discord.com/developers/docs/resources/channel#get-channel-messages-query-string-params
 // TODO: ensure limits
-type GetMessagesParams struct {
+type GetMessages struct {
 	Around Snowflake `urlparam:"around,omitempty"`
 	Before Snowflake `urlparam:"before,omitempty"`
 	After  Snowflake `urlparam:"after,omitempty"`
 	Limit  uint      `urlparam:"limit,omitempty"`
 }
 
-func (g *GetMessagesParams) Validate() error {
+func (g *GetMessages) Validate() error {
 	var mutuallyExclusives int
 	if !g.Around.IsZero() {
 		mutuallyExclusives++
@@ -700,7 +700,7 @@ func (g *GetMessagesParams) Validate() error {
 	return nil
 }
 
-var _ URLQueryStringer = (*GetMessagesParams)(nil)
+var _ URLQueryStringer = (*GetMessages)(nil)
 
 // getMessages [REST] Returns the messages for a channel. If operating on a guild channel, this endpoint requires
 // the 'VIEW_CHANNEL' permission to be present on the current user. If the current user is missing
@@ -736,7 +736,7 @@ func (c channelQueryBuilder) getMessages(params URLQueryStringer) (ret []*Messag
 }
 
 // GetMessages bypasses discord limitations and iteratively fetches messages until the set filters are met.
-func (c channelQueryBuilder) GetMessages(filter *GetMessagesParams) (messages []*Message, err error) {
+func (c channelQueryBuilder) GetMessages(filter *GetMessages) (messages []*Message, err error) {
 	// discord values
 	const filterLimit = 100
 	const filterDefault = 50
@@ -838,13 +838,13 @@ func (c channelQueryBuilder) GetMessages(filter *GetMessagesParams) (messages []
 	return messages, nil
 }
 
-// DeleteMessagesParams https://discord.com/developers/docs/resources/channel#bulk-delete-messages-json-params
-type DeleteMessagesParams struct {
+// DeleteMessages https://discord.com/developers/docs/resources/channel#bulk-delete-messages-json-params
+type DeleteMessages struct {
 	Messages []Snowflake `json:"messages"`
 	m        sync.RWMutex
 }
 
-func (p *DeleteMessagesParams) tooMany(messages int) (err error) {
+func (p *DeleteMessages) tooMany(messages int) (err error) {
 	if messages > 100 {
 		err = errors.New("must be 100 or less messages to delete")
 	}
@@ -852,7 +852,7 @@ func (p *DeleteMessagesParams) tooMany(messages int) (err error) {
 	return
 }
 
-func (p *DeleteMessagesParams) tooFew(messages int) (err error) {
+func (p *DeleteMessages) tooFew(messages int) (err error) {
 	if messages < 2 {
 		err = errors.New("must be at least two messages to delete")
 	}
@@ -860,8 +860,8 @@ func (p *DeleteMessagesParams) tooFew(messages int) (err error) {
 	return
 }
 
-// Valid validates the DeleteMessagesParams data
-func (p *DeleteMessagesParams) Valid() (err error) {
+// Valid validates the DeleteMessages data
+func (p *DeleteMessages) Valid() (err error) {
 	p.m.RLock()
 	defer p.m.RUnlock()
 
@@ -874,7 +874,7 @@ func (p *DeleteMessagesParams) Valid() (err error) {
 }
 
 // AddMessage Adds a message to be deleted
-func (p *DeleteMessagesParams) AddMessage(msg *Message) (err error) {
+func (p *DeleteMessages) AddMessage(msg *Message) (err error) {
 	p.m.Lock()
 	defer p.m.Unlock()
 
@@ -899,7 +899,7 @@ func (p *DeleteMessagesParams) AddMessage(msg *Message) (err error) {
 //  Reviewed                2018-06-10
 //  Comment                 This endpoint will not delete messages older than 2 weeks, and will fail if any message
 //                          provided is older than that.
-func (c channelQueryBuilder) DeleteMessages(params *DeleteMessagesParams) (err error) {
+func (c channelQueryBuilder) DeleteMessages(params *DeleteMessages) (err error) {
 	if c.cid.IsZero() {
 		err = errors.New("channelID must be set to get channel messages")
 		return err
@@ -930,9 +930,9 @@ type AllowedMentions struct {
 	RepliedUser bool        `json:"replied_user,omitempty"`
 }
 
-// CreateMessageFileParams contains the information needed to upload a file to Discord, it is part of the
-// CreateMessageParams struct.
-type CreateMessageFileParams struct {
+// CreateMessageFile contains the information needed to upload a file to Discord, it is part of the
+// CreateMessage struct.
+type CreateMessageFile struct {
 	Reader   io.Reader `json:"-"` // always omit as we don't want this as part of the JSON payload
 	FileName string    `json:"-"`
 
@@ -943,7 +943,7 @@ type CreateMessageFileParams struct {
 }
 
 // write helper for file uploading in messages
-func (f *CreateMessageFileParams) write(i int, mp *multipart.Writer) error {
+func (f *CreateMessageFile) write(i int, mp *multipart.Writer) error {
 	var filename string
 	if f.SpoilerTag {
 		filename = AttachmentSpoilerPrefix + f.FileName
@@ -962,14 +962,14 @@ func (f *CreateMessageFileParams) write(i int, mp *multipart.Writer) error {
 	return nil
 }
 
-// CreateMessageParams JSON params for CreateChannelMessage
-type CreateMessageParams struct {
-	Content    string                    `json:"content"`
-	Nonce      string                    `json:"nonce,omitempty"` // THIS IS A STRING. NOT A SNOWFLAKE! DONT TOUCH!
-	Tts        bool                      `json:"tts,omitempty"`
-	Embed      *Embed                    `json:"embed,omitempty"` // embedded rich content
-	Components []*MessageComponent       `json:"components"`
-	Files      []CreateMessageFileParams `json:"-"` // Always omit as this is included in multipart, not JSON payload
+// CreateMessage JSON params for CreateChannelMessage
+type CreateMessage struct {
+	Content    string              `json:"content"`
+	Nonce      string              `json:"nonce,omitempty"` // THIS IS A STRING. NOT A SNOWFLAKE! DONT TOUCH!
+	Tts        bool                `json:"tts,omitempty"`
+	Embed      *Embed              `json:"embed,omitempty"` // embedded rich content
+	Components []*MessageComponent `json:"components"`
+	Files      []CreateMessageFile `json:"-"` // Always omit as this is included in multipart, not JSON payload
 
 	SpoilerTagContent        bool `json:"-"`
 	SpoilerTagAllAttachments bool `json:"-"`
@@ -978,7 +978,7 @@ type CreateMessageParams struct {
 	MessageReference *MessageReference `json:"message_reference,omitempty"`
 }
 
-func (p *CreateMessageParams) prepare() (postBody interface{}, contentType string, err error) {
+func (p *CreateMessage) prepare() (postBody interface{}, contentType string, err error) {
 	// spoiler tag
 	if p.SpoilerTagContent && len(p.Content) > 0 {
 		p.Content = "|| " + p.Content + " ||"
@@ -1048,7 +1048,7 @@ func (p *CreateMessageParams) prepare() (postBody interface{}, contentType strin
 //  Discord documentation   https://discord.com/developers/docs/resources/channel#create-message
 //  Reviewed                2018-06-10
 //  Comment                 Before using this endpoint, you must connect to and identify with a gateway at least once.
-func (c channelQueryBuilder) CreateMessage(params *CreateMessageParams) (ret *Message, err error) {
+func (c channelQueryBuilder) CreateMessage(params *CreateMessage) (ret *Message, err error) {
 	if c.cid.IsZero() {
 		err = errors.New("channelID must be set to get channel messages")
 		return nil, err
@@ -1101,9 +1101,9 @@ func (c channelQueryBuilder) GetPinnedMessages() (ret []*Message, err error) {
 	return getMessages(r.Execute)
 }
 
-// CreateWebhookParams json params for the create webhook rest request avatar string
+// CreateWebhook json params for the create webhook rest request avatar string
 // https://discord.com/developers/docs/resources/user#avatar-data
-type CreateWebhookParams struct {
+type CreateWebhook struct {
 	Name   string `json:"name"`   // name of the webhook (2-32 characters)
 	Avatar string `json:"avatar"` // avatar data uri scheme, image for the default webhook avatar
 
@@ -1111,7 +1111,7 @@ type CreateWebhookParams struct {
 	Reason string `json:"-"`
 }
 
-func (c *CreateWebhookParams) FindErrors() error {
+func (c *CreateWebhook) FindErrors() error {
 	if c.Name == "" {
 		return errors.New("webhook must have a name")
 	}
@@ -1128,7 +1128,7 @@ func (c *CreateWebhookParams) FindErrors() error {
 //  Discord documentation   https://discord.com/developers/docs/resources/webhook#create-webhook
 //  Reviewed                2018-08-14
 //  Comment                 -
-func (c channelQueryBuilder) CreateWebhook(params *CreateWebhookParams) (ret *Webhook, err error) {
+func (c channelQueryBuilder) CreateWebhook(params *CreateWebhook) (ret *Webhook, err error) {
 	if params == nil {
 		return nil, errors.New("params was nil")
 	}
@@ -1176,7 +1176,7 @@ func (c channelQueryBuilder) GetWebhooks() (ret []*Webhook, err error) {
 // Reviewed                 2021-11-21 (self)
 // Comment                  This endpoint supports the X-Audit-Log-Reason header.
 
-func (c channelQueryBuilder) CreateThread(messageID Snowflake, params *CreateThreadParams) (*Channel, error) {
+func (c channelQueryBuilder) CreateThread(messageID Snowflake, params *CreateThread) (*Channel, error) {
 	if params == nil || params.Name == "" {
 		return nil, errors.New("thread name is required")
 	}
@@ -1206,7 +1206,7 @@ func (c channelQueryBuilder) CreateThread(messageID Snowflake, params *CreateThr
 // Reviewed                        2021-11-22 (self)
 // Comment                         This endpoint supports the X-Audit-Log-Reason header.
 
-func (c channelQueryBuilder) CreateThreadNoMessage(params *CreateThreadParamsNoMessage) (*Channel, error) {
+func (c channelQueryBuilder) CreateThreadNoMessage(params *CreateThreadNoMessage) (*Channel, error) {
 	if params == nil || params.Name == "" {
 		return nil, errors.New("thread name is required")
 	}
@@ -1359,12 +1359,12 @@ type ResponseBodyThreads struct {
 }
 
 // https://discord.com/developers/docs/resources/channel#list-public-archived-threads-query-string-params
-type GetThreadsParams struct {
+type GetThreads struct {
 	Before Time `urlparam:"before,omitempty"`
 	Limit  int  `urlparam:"limit,omitempty"`
 }
 
-var _ URLQueryStringer = (*GetThreadsParams)(nil)
+var _ URLQueryStringer = (*GetThreads)(nil)
 
 // GetPublicArchivedThreads [GET]    Returns archived threads in the channel that are public. When called
 //                                   on a GUILD_TEXT channel, returns threads of type GUILD_PUBLIC_THREAD.
@@ -1376,7 +1376,7 @@ var _ URLQueryStringer = (*GetThreadsParams)(nil)
 // Reviewed                          2021-11-22 (self)
 // Comment
 
-func (c channelQueryBuilder) GetPublicArchivedThreads(params *GetThreadsParams) (*ResponseBodyThreads, error) {
+func (c channelQueryBuilder) GetPublicArchivedThreads(params *GetThreads) (*ResponseBodyThreads, error) {
 	var query string
 	if params != nil {
 		query += params.URLQueryString()
@@ -1406,7 +1406,7 @@ func (c channelQueryBuilder) GetPublicArchivedThreads(params *GetThreadsParams) 
 // Reviewed                           2021-11-24 (self)
 // Comment
 
-func (c channelQueryBuilder) GetPrivateArchivedThreads(params *GetThreadsParams) (*ResponseBodyThreads, error) {
+func (c channelQueryBuilder) GetPrivateArchivedThreads(params *GetThreads) (*ResponseBodyThreads, error) {
 	var query string
 	if params != nil {
 		query += params.URLQueryString()
@@ -1435,7 +1435,7 @@ func (c channelQueryBuilder) GetPrivateArchivedThreads(params *GetThreadsParams)
 // Reviewed                                 2021-11-24 (self)
 // Comment
 
-func (c channelQueryBuilder) GetJoinedPrivateArchivedThreads(params *GetThreadsParams) (*ResponseBodyThreads, error) {
+func (c channelQueryBuilder) GetJoinedPrivateArchivedThreads(params *GetThreads) (*ResponseBodyThreads, error) {
 	var query string
 	if params != nil {
 		query += params.URLQueryString()

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -148,7 +148,7 @@ func TestClient(t *testing.T) {
 
 		var roleID Snowflake
 		t.Run("create", func(t *testing.T) {
-			createdRole, err := c.Guild(guildAdmin.ID).CreateRole(&CreateGuildRoleParams{
+			createdRole, err := c.Guild(guildAdmin.ID).CreateRole(&CreateGuildRole{
 				Name:   roleName,
 				Reason: "integration test",
 			})
@@ -385,7 +385,7 @@ func TestClient(t *testing.T) {
 		}
 
 		c.Gateway().WithMiddleware(filterChannel, filterTestPrefix).MessageCreateChan(gotMessage)
-		_, err := c.Channel(channelID).WithContext(deadline).CreateMessage(&CreateMessageParams{Content: content})
+		_, err := c.Channel(channelID).WithContext(deadline).CreateMessage(&CreateMessage{Content: content})
 		if err != nil {
 			panic(fmt.Errorf("unable to send message. %w", err))
 		}
@@ -627,7 +627,7 @@ func TestREST(t *testing.T) {
 			}
 
 			content := "hi"
-			msg, err := c.Channel(channel.ID).WithContext(deadline).CreateMessage(&CreateMessageParams{Content: content})
+			msg, err := c.Channel(channel.ID).WithContext(deadline).CreateMessage(&CreateMessage{Content: content})
 			if err != nil {
 				t.Error(fmt.Errorf("unable to create message in DM channel. %w", err))
 			}

--- a/cmd/bot-REST-tester/main.go
+++ b/cmd/bot-REST-tester/main.go
@@ -148,7 +148,7 @@ func main() {
 
 		// create emoji
 		func() {
-			emoji, err = c.Guild(keys.GuildDefault).CreateEmoji(&disgord.CreateGuildEmojiParams{
+			emoji, err = c.Guild(keys.GuildDefault).CreateEmoji(&disgord.CreateGuildEmoji{
 				Name:  "testing4324",
 				Image: randomBase64Emoji,
 			})
@@ -184,7 +184,7 @@ func main() {
 
 		// create emoji
 		func() {
-			emoji, err = c.Guild(keys.GuildDefault).CreateEmoji(&disgord.CreateGuildEmojiParams{Name: "test6547465", Image: randomBase64Emoji})
+			emoji, err = c.Guild(keys.GuildDefault).CreateEmoji(&disgord.CreateGuildEmoji{Name: "test6547465", Image: randomBase64Emoji})
 			if err != nil && !notARateLimitIssue(err) {
 				panic("rate limited")
 			} else if err != nil && notARateLimitIssue(err) {
@@ -229,7 +229,7 @@ func main() {
 		// create emoji
 		func() {
 
-			emoji, err = c.Guild(keys.GuildAdmin).CreateEmoji(&disgord.CreateGuildEmojiParams{
+			emoji, err = c.Guild(keys.GuildAdmin).CreateEmoji(&disgord.CreateGuildEmoji{
 				Name:  illegalNames[0],
 				Image: randomBase64Emoji,
 			})

--- a/cmd/bots/spoiler-tag/main.go
+++ b/cmd/bots/spoiler-tag/main.go
@@ -14,7 +14,7 @@ package main
 // 	})
 //
 // 	chanID := disgord.Snowflake(540519296640614416)
-// 	_, err := c.Channel(chanID).CreateMessage(&disgord.CreateMessageParams{
+// 	_, err := c.Channel(chanID).CreateMessage(&disgord.CreateMessage{
 // 		Content:           "testing",
 // 		SpoilerTagContent: true,
 // 	})
@@ -30,9 +30,9 @@ package main
 // 	}
 // 	defer f2.Close()
 //
-// 	_, _ = c.Channel(chanID).CreateMessage(&disgord.CreateMessageParams{
+// 	_, _ = c.Channel(chanID).CreateMessage(&disgord.CreateMessage{
 // 		Content: "with embed",
-// 		Files: []disgord.CreateMessageFileParams{
+// 		Files: []disgord.CreateMessageFile{
 // 			{Reader: f1, FileName: "myfavouriteimage.jpg", SpoilerTag: true},
 // 			{Reader: f2, FileName: "another.jpg"},
 // 		},
@@ -44,9 +44,9 @@ package main
 // 		},
 // 	})
 //
-// 	_, _ = c.Channel(chanID).CreateMessage(&disgord.CreateMessageParams{
+// 	_, _ = c.Channel(chanID).CreateMessage(&disgord.CreateMessage{
 // 		Content: "This is my favourite image, and another in an embed!",
-// 		Files: []disgord.CreateMessageFileParams{
+// 		Files: []disgord.CreateMessageFile{
 // 			{Reader: f1, FileName: "myfavouriteimage.jpg"},
 // 			{Reader: f2, FileName: "another.jpg", SpoilerTag: true},
 // 		},

--- a/deprecated.go
+++ b/deprecated.go
@@ -1,1 +1,0 @@
-package disgord

--- a/deprecated.rest-struct-params.go
+++ b/deprecated.rest-struct-params.go
@@ -1,0 +1,91 @@
+package disgord
+
+// Deprecated: use UpdateChannelPermissions
+type UpdateChannelPermissionsParams = UpdateChannelPermissions
+
+// Deprecated: use UpdateGuildIntegration
+type UpdateGuildIntegrationParams = UpdateGuildIntegration
+
+// Deprecated: use GetMessages
+type GetMessagesParams = GetMessages
+
+// Deprecated: use DeleteMessages
+type DeleteMessagesParams = DeleteMessages
+
+// Deprecated: use CreateMessageFile
+type CreateMessageFileParams = CreateMessageFile
+
+// Deprecated: use CreateMessage
+type CreateMessageParams = CreateMessage
+
+// Deprecated: use CreateWebhook
+type CreateWebhookParams = CreateWebhook
+
+// Deprecated: use GetThreads
+type GetThreadsParams = GetThreads
+
+// Deprecated: use GetCurrentUserGuilds
+type GetCurrentUserGuildsParams = GetCurrentUserGuilds
+
+// Deprecated: use CreateGroupDM
+type CreateGroupDMParams = CreateGroupDM
+
+// Deprecated: use CreateGuild
+type CreateGuildParams = CreateGuild
+
+// Deprecated: use CreateGuildRole
+type CreateGuildRoleParams = CreateGuildRole
+
+// Deprecated: use CreateGuildEmoji
+type CreateGuildEmojiParams = CreateGuildEmoji
+
+// Deprecated: use CreateGuildChannel
+type CreateGuildChannelParams = CreateGuildChannel
+
+// Deprecated: use UpdateGuildChannelPositions
+type UpdateGuildChannelPositionsParams = UpdateGuildChannelPositions
+
+// Deprecated: use UpdateGuildRolePositions
+type UpdateGuildRolePositionsParams = UpdateGuildRolePositions
+
+// Deprecated: use getGuildMembers
+type getGuildMembersParams = getGuildMembers
+
+// Deprecated: use GetMembers
+type GetMembersParams = GetMembers
+
+// Deprecated: use AddGuildMember
+type AddGuildMemberParams = AddGuildMember
+
+// Deprecated: use BanMember
+type BanMemberParams = BanMember
+
+// Deprecated: use pruneMembers
+type pruneMembersParams = pruneMembers
+
+// Deprecated: use CreateGuildIntegration
+type CreateGuildIntegrationParams = CreateGuildIntegration
+
+// Deprecated: use ExecuteWebhook
+type ExecuteWebhookParams = ExecuteWebhook
+
+// Deprecated: use execWebhook
+type execWebhookParams = execWebhook
+
+// Deprecated: use CreateThread
+type CreateThreadParams = CreateThread
+
+// Deprecated: use CreateThreadNoMessage
+type CreateThreadParamsNoMessage = CreateThreadNoMessage
+
+// Deprecated: use updateCurrentUserNick
+type updateCurrentUserNickParams = updateCurrentUserNick
+
+// Deprecated: use NewUpdateGuildRolePositions
+var NewUpdateGuildRolePositionsParams = NewUpdateGuildRolePositions
+
+// Deprecated: use getInviteQuery
+type getInviteParams = getInviteQuery
+
+// Deprecated: use GetReactionURL
+type GetReactionURLParams = GetReactionURL

--- a/disgordtest/query_builders_nop_gen.go
+++ b/disgordtest/query_builders_nop_gen.go
@@ -72,19 +72,19 @@ func (c *ChannelQueryBuilderNop) CreateInvite() disgord.CreateChannelInviteBuild
 	return nil
 }
 
-func (c *ChannelQueryBuilderNop) CreateMessage(_ *disgord.CreateMessageParams) (*disgord.Message, error) {
+func (c *ChannelQueryBuilderNop) CreateMessage(_ *disgord.CreateMessage) (*disgord.Message, error) {
 	return nil, nil
 }
 
-func (c *ChannelQueryBuilderNop) CreateThread(_ disgord.Snowflake, _ *disgord.CreateThreadParams) (*disgord.Channel, error) {
+func (c *ChannelQueryBuilderNop) CreateThread(_ disgord.Snowflake, _ *disgord.CreateThread) (*disgord.Channel, error) {
 	return nil, nil
 }
 
-func (c *ChannelQueryBuilderNop) CreateThreadNoMessage(_ *disgord.CreateThreadParamsNoMessage) (*disgord.Channel, error) {
+func (c *ChannelQueryBuilderNop) CreateThreadNoMessage(_ *disgord.CreateThreadNoMessage) (*disgord.Channel, error) {
 	return nil, nil
 }
 
-func (c *ChannelQueryBuilderNop) CreateWebhook(_ *disgord.CreateWebhookParams) (*disgord.Webhook, error) {
+func (c *ChannelQueryBuilderNop) CreateWebhook(_ *disgord.CreateWebhook) (*disgord.Webhook, error) {
 	return nil, nil
 }
 
@@ -92,7 +92,7 @@ func (c *ChannelQueryBuilderNop) Delete() (*disgord.Channel, error) {
 	return nil, nil
 }
 
-func (c *ChannelQueryBuilderNop) DeleteMessages(_ *disgord.DeleteMessagesParams) error {
+func (c *ChannelQueryBuilderNop) DeleteMessages(_ *disgord.DeleteMessages) error {
 	return nil
 }
 
@@ -108,11 +108,11 @@ func (c *ChannelQueryBuilderNop) GetInvites() ([]*disgord.Invite, error) {
 	return nil, nil
 }
 
-func (c *ChannelQueryBuilderNop) GetJoinedPrivateArchivedThreads(_ *disgord.GetThreadsParams) (*disgord.ResponseBodyThreads, error) {
+func (c *ChannelQueryBuilderNop) GetJoinedPrivateArchivedThreads(_ *disgord.GetThreads) (*disgord.ResponseBodyThreads, error) {
 	return nil, nil
 }
 
-func (c *ChannelQueryBuilderNop) GetMessages(_ *disgord.GetMessagesParams) ([]*disgord.Message, error) {
+func (c *ChannelQueryBuilderNop) GetMessages(_ *disgord.GetMessages) ([]*disgord.Message, error) {
 	return nil, nil
 }
 
@@ -120,11 +120,11 @@ func (c *ChannelQueryBuilderNop) GetPinnedMessages() ([]*disgord.Message, error)
 	return nil, nil
 }
 
-func (c *ChannelQueryBuilderNop) GetPrivateArchivedThreads(_ *disgord.GetThreadsParams) (*disgord.ResponseBodyThreads, error) {
+func (c *ChannelQueryBuilderNop) GetPrivateArchivedThreads(_ *disgord.GetThreads) (*disgord.ResponseBodyThreads, error) {
 	return nil, nil
 }
 
-func (c *ChannelQueryBuilderNop) GetPublicArchivedThreads(_ *disgord.GetThreadsParams) (*disgord.ResponseBodyThreads, error) {
+func (c *ChannelQueryBuilderNop) GetPublicArchivedThreads(_ *disgord.GetThreads) (*disgord.ResponseBodyThreads, error) {
 	return nil, nil
 }
 
@@ -168,7 +168,7 @@ func (c *ChannelQueryBuilderNop) UpdateBuilder() disgord.UpdateChannelBuilder {
 	return nil
 }
 
-func (c *ChannelQueryBuilderNop) UpdatePermissions(_ disgord.Snowflake, _ *disgord.UpdateChannelPermissionsParams) error {
+func (c *ChannelQueryBuilderNop) UpdatePermissions(_ disgord.Snowflake, _ *disgord.UpdateChannelPermissions) error {
 	return nil
 }
 
@@ -204,7 +204,7 @@ func (c *ClientQueryBuilderNop) Channel(_ disgord.Snowflake) disgord.ChannelQuer
 	return nil
 }
 
-func (c *ClientQueryBuilderNop) CreateGuild(_ string, _ *disgord.CreateGuildParams) (*disgord.Guild, error) {
+func (c *ClientQueryBuilderNop) CreateGuild(_ string, _ *disgord.CreateGuild) (*disgord.Guild, error) {
 	return nil, nil
 }
 
@@ -256,7 +256,7 @@ func (c CurrentUserQueryBuilderNop) WithFlags(flags ...disgord.Flag) disgord.Cur
 	return &c
 }
 
-func (c *CurrentUserQueryBuilderNop) CreateGroupDM(_ *disgord.CreateGroupDMParams) (*disgord.Channel, error) {
+func (c *CurrentUserQueryBuilderNop) CreateGroupDM(_ *disgord.CreateGroupDM) (*disgord.Channel, error) {
 	return nil, nil
 }
 
@@ -264,7 +264,7 @@ func (c *CurrentUserQueryBuilderNop) Get() (*disgord.User, error) {
 	return nil, nil
 }
 
-func (c *CurrentUserQueryBuilderNop) GetGuilds(_ *disgord.GetCurrentUserGuildsParams) ([]*disgord.Guild, error) {
+func (c *CurrentUserQueryBuilderNop) GetGuilds(_ *disgord.GetCurrentUserGuilds) ([]*disgord.Guild, error) {
 	return nil, nil
 }
 
@@ -739,7 +739,7 @@ func (g *GuildMemberQueryBuilderNop) AddRole(_ disgord.Snowflake) error {
 	return nil
 }
 
-func (g *GuildMemberQueryBuilderNop) Ban(_ *disgord.BanMemberParams) error {
+func (g *GuildMemberQueryBuilderNop) Ban(_ *disgord.BanMember) error {
 	return nil
 }
 
@@ -783,23 +783,23 @@ func (g GuildQueryBuilderNop) WithFlags(flags ...disgord.Flag) disgord.GuildQuer
 	return &g
 }
 
-func (g *GuildQueryBuilderNop) CreateChannel(_ string, _ *disgord.CreateGuildChannelParams) (*disgord.Channel, error) {
+func (g *GuildQueryBuilderNop) CreateChannel(_ string, _ *disgord.CreateGuildChannel) (*disgord.Channel, error) {
 	return nil, nil
 }
 
-func (g *GuildQueryBuilderNop) CreateEmoji(_ *disgord.CreateGuildEmojiParams) (*disgord.Emoji, error) {
+func (g *GuildQueryBuilderNop) CreateEmoji(_ *disgord.CreateGuildEmoji) (*disgord.Emoji, error) {
 	return nil, nil
 }
 
-func (g *GuildQueryBuilderNop) CreateIntegration(_ *disgord.CreateGuildIntegrationParams) error {
+func (g *GuildQueryBuilderNop) CreateIntegration(_ *disgord.CreateGuildIntegration) error {
 	return nil
 }
 
-func (g *GuildQueryBuilderNop) CreateMember(_ disgord.Snowflake, _ string, _ *disgord.AddGuildMemberParams) (*disgord.Member, error) {
+func (g *GuildQueryBuilderNop) CreateMember(_ disgord.Snowflake, _ string, _ *disgord.AddGuildMember) (*disgord.Member, error) {
 	return nil, nil
 }
 
-func (g *GuildQueryBuilderNop) CreateRole(_ *disgord.CreateGuildRoleParams) (*disgord.Role, error) {
+func (g *GuildQueryBuilderNop) CreateRole(_ *disgord.CreateGuildRole) (*disgord.Role, error) {
 	return nil, nil
 }
 
@@ -859,7 +859,7 @@ func (g *GuildQueryBuilderNop) GetInvites() ([]*disgord.Invite, error) {
 	return nil, nil
 }
 
-func (g *GuildQueryBuilderNop) GetMembers(_ *disgord.GetMembersParams) ([]*disgord.Member, error) {
+func (g *GuildQueryBuilderNop) GetMembers(_ *disgord.GetMembers) ([]*disgord.Member, error) {
 	return nil, nil
 }
 
@@ -911,7 +911,7 @@ func (g *GuildQueryBuilderNop) UpdateBuilder() disgord.UpdateGuildBuilder {
 	return nil
 }
 
-func (g *GuildQueryBuilderNop) UpdateChannelPositions(_ []disgord.UpdateGuildChannelPositionsParams) error {
+func (g *GuildQueryBuilderNop) UpdateChannelPositions(_ []disgord.UpdateGuildChannelPositions) error {
 	return nil
 }
 
@@ -919,11 +919,11 @@ func (g *GuildQueryBuilderNop) UpdateEmbedBuilder() disgord.UpdateGuildEmbedBuil
 	return nil
 }
 
-func (g *GuildQueryBuilderNop) UpdateIntegration(_ disgord.Snowflake, _ *disgord.UpdateGuildIntegrationParams) error {
+func (g *GuildQueryBuilderNop) UpdateIntegration(_ disgord.Snowflake, _ *disgord.UpdateGuildIntegration) error {
 	return nil
 }
 
-func (g *GuildQueryBuilderNop) UpdateRolePositions(_ []disgord.UpdateGuildRolePositionsParams) ([]*disgord.Role, error) {
+func (g *GuildQueryBuilderNop) UpdateRolePositions(_ []disgord.UpdateGuildRolePositions) ([]*disgord.Role, error) {
 	return nil, nil
 }
 
@@ -1163,7 +1163,7 @@ func (v *VoiceChannelQueryBuilderNop) UpdateBuilder() disgord.UpdateChannelBuild
 	return nil
 }
 
-func (v *VoiceChannelQueryBuilderNop) UpdatePermissions(_ disgord.Snowflake, _ *disgord.UpdateChannelPermissionsParams) error {
+func (v *VoiceChannelQueryBuilderNop) UpdatePermissions(_ disgord.Snowflake, _ *disgord.UpdateChannelPermissions) error {
 	return nil
 }
 
@@ -1191,15 +1191,15 @@ func (w *WebhookQueryBuilderNop) Delete() error {
 	return nil
 }
 
-func (w *WebhookQueryBuilderNop) Execute(_ *disgord.ExecuteWebhookParams, _ bool, _ disgord.Snowflake, _ string) (*disgord.Message, error) {
+func (w *WebhookQueryBuilderNop) Execute(_ *disgord.ExecuteWebhook, _ bool, _ disgord.Snowflake, _ string) (*disgord.Message, error) {
 	return nil, nil
 }
 
-func (w *WebhookQueryBuilderNop) ExecuteGitHubWebhook(_ *disgord.ExecuteWebhookParams, _ bool, _ disgord.Snowflake) (*disgord.Message, error) {
+func (w *WebhookQueryBuilderNop) ExecuteGitHubWebhook(_ *disgord.ExecuteWebhook, _ bool, _ disgord.Snowflake) (*disgord.Message, error) {
 	return nil, nil
 }
 
-func (w *WebhookQueryBuilderNop) ExecuteSlackWebhook(_ *disgord.ExecuteWebhookParams, _ bool, _ disgord.Snowflake) (*disgord.Message, error) {
+func (w *WebhookQueryBuilderNop) ExecuteSlackWebhook(_ *disgord.ExecuteWebhook, _ bool, _ disgord.Snowflake) (*disgord.Message, error) {
 	return nil, nil
 }
 
@@ -1239,7 +1239,7 @@ func (w *WebhookWithTokenQueryBuilderNop) Delete() error {
 	return nil
 }
 
-func (w *WebhookWithTokenQueryBuilderNop) Execute(_ *disgord.ExecuteWebhookParams, _ bool, _ disgord.Snowflake, _ string) (*disgord.Message, error) {
+func (w *WebhookWithTokenQueryBuilderNop) Execute(_ *disgord.ExecuteWebhook, _ bool, _ disgord.Snowflake, _ string) (*disgord.Message, error) {
 	return nil, nil
 }
 

--- a/docs/examples/create-threads/main.go
+++ b/docs/examples/create-threads/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strings"
-	"fmt"
 
 	"github.com/sirupsen/logrus"
 
@@ -18,7 +18,7 @@ var log = &logrus.Logger{
 }
 
 func threadNeedsName(session disgord.Session, channelID disgord.Snowflake, usageText string) {
-	_, err := session.Channel(channelID).CreateMessage(&disgord.CreateMessageParams{
+	_, err := session.Channel(channelID).CreateMessage(&disgord.CreateMessage{
 		Content: fmt.Sprintf("Thread name is a required input. Usage: `%s`", usageText),
 	})
 	if err != nil {
@@ -34,7 +34,7 @@ func msgHandler(session disgord.Session, evt *disgord.MessageCreate) {
 			threadNeedsName(session, evt.Message.ChannelID, "$makethread my-awesome-thread-name")
 		} else {
 			threadName := strs[1]
-			thread, err := session.Channel(evt.Message.ChannelID).CreateThread(evt.Message.ID, &disgord.CreateThreadParams{
+			thread, err := session.Channel(evt.Message.ChannelID).CreateThread(evt.Message.ID, &disgord.CreateThread{
 				Name: threadName,
 				// any auto archive thread duration greater than AutoArchiveThreadDay requires premium
 				AutoArchiveDuration: disgord.AutoArchiveThreadDay,
@@ -43,7 +43,7 @@ func msgHandler(session disgord.Session, evt *disgord.MessageCreate) {
 				log.Error(err)
 			}
 			// send a message in the newly created thread
-			_, err = session.Channel(thread.ID).CreateMessage(&disgord.CreateMessageParams{Content: "HELLO WORLD"})
+			_, err = session.Channel(thread.ID).CreateMessage(&disgord.CreateMessage{Content: "HELLO WORLD"})
 			if err != nil {
 				log.Error(err)
 			}
@@ -53,7 +53,7 @@ func msgHandler(session disgord.Session, evt *disgord.MessageCreate) {
 			threadNeedsName(session, evt.Message.ChannelID, "$makethreadnomessage my-awesome-thread-name")
 		} else {
 			threadName := strs[1]
-			thread, err := session.Channel(evt.Message.ChannelID).CreateThreadNoMessage(&disgord.CreateThreadParamsNoMessage{
+			thread, err := session.Channel(evt.Message.ChannelID).CreateThreadNoMessage(&disgord.CreateThreadNoMessage{
 				Name: threadName,
 				// any auto archive thread duration greater than AutoArchiveThreadDay requires premium
 				AutoArchiveDuration: disgord.AutoArchiveThreadDay,
@@ -63,7 +63,7 @@ func msgHandler(session disgord.Session, evt *disgord.MessageCreate) {
 				log.Error(err)
 			}
 			// send a message in the newly created thread
-			_, err = session.Channel(thread.ID).CreateMessage(&disgord.CreateMessageParams{Content: "HELLO WORLD"})
+			_, err = session.Channel(thread.ID).CreateMessage(&disgord.CreateMessage{Content: "HELLO WORLD"})
 			if err != nil {
 				log.Error(err)
 			}

--- a/docs/examples/upload-images/bot.go
+++ b/docs/examples/upload-images/bot.go
@@ -29,9 +29,9 @@ func main() {
 	}
 	defer f2.Close()
 
-	_, errUpload := client.Channel(ChannelID).CreateMessage(&disgord.CreateMessageParams{
+	_, errUpload := client.Channel(ChannelID).CreateMessage(&disgord.CreateMessage{
 		Content: "This is my favourite image, and another in an embed!",
-		Files: []disgord.CreateMessageFileParams{
+		Files: []disgord.CreateMessageFile{
 			{f1, "myfavouriteimage.jpg", false},
 			{f2, "another.jpg", false},
 		},

--- a/iface_urlquerystringer_gen.go
+++ b/iface_urlquerystringer_gen.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func (g *GetMessagesParams) URLQueryString() string {
+func (g *GetMessages) URLQueryString() string {
 	params := make(urlQuery)
 
 	if !(g.Around == 0) {
@@ -28,7 +28,7 @@ func (g *GetMessagesParams) URLQueryString() string {
 	return params.URLQueryString()
 }
 
-func (g *GetThreadsParams) URLQueryString() string {
+func (g *GetThreads) URLQueryString() string {
 	params := make(urlQuery)
 
 	if !(g.Before == Time{time.Unix(0, 0)}) {
@@ -42,7 +42,7 @@ func (g *GetThreadsParams) URLQueryString() string {
 	return params.URLQueryString()
 }
 
-func (g *getGuildMembersParams) URLQueryString() string {
+func (g *getGuildMembers) URLQueryString() string {
 	params := make(urlQuery)
 
 	if !(g.After == 0) {
@@ -56,7 +56,7 @@ func (g *getGuildMembersParams) URLQueryString() string {
 	return params.URLQueryString()
 }
 
-func (b *BanMemberParams) URLQueryString() string {
+func (b *BanMember) URLQueryString() string {
 	params := make(urlQuery)
 
 	if !(b.DeleteMessageDays == 0) {
@@ -70,7 +70,7 @@ func (b *BanMemberParams) URLQueryString() string {
 	return params.URLQueryString()
 }
 
-func (p *pruneMembersParams) URLQueryString() string {
+func (p *pruneMembers) URLQueryString() string {
 	params := make(urlQuery)
 
 	params["days"] = p.Days
@@ -80,7 +80,7 @@ func (p *pruneMembersParams) URLQueryString() string {
 	return params.URLQueryString()
 }
 
-func (g *getInviteParams) URLQueryString() string {
+func (g *getInviteQuery) URLQueryString() string {
 	params := make(urlQuery)
 
 	if !(g.WithMemberCount == false) {
@@ -90,7 +90,7 @@ func (g *getInviteParams) URLQueryString() string {
 	return params.URLQueryString()
 }
 
-func (g *GetReactionURLParams) URLQueryString() string {
+func (g *GetReactionURL) URLQueryString() string {
 	params := make(urlQuery)
 
 	if !(g.Before == 0) {
@@ -108,7 +108,7 @@ func (g *GetReactionURLParams) URLQueryString() string {
 	return params.URLQueryString()
 }
 
-func (g *GetCurrentUserGuildsParams) URLQueryString() string {
+func (g *GetCurrentUserGuilds) URLQueryString() string {
 	params := make(urlQuery)
 
 	if !(g.Before == 0) {
@@ -126,7 +126,7 @@ func (g *GetCurrentUserGuildsParams) URLQueryString() string {
 	return params.URLQueryString()
 }
 
-func (e *execWebhookParams) URLQueryString() string {
+func (e *execWebhook) URLQueryString() string {
 	params := make(urlQuery)
 
 	params["wait"] = e.Wait

--- a/internal/gateway/diagnose_false.go
+++ b/internal/gateway/diagnose_false.go
@@ -1,3 +1,4 @@
+//go:build !disgord_diagnosews
 // +build !disgord_diagnosews
 
 package gateway

--- a/internal/gateway/diagnose_true.go
+++ b/internal/gateway/diagnose_true.go
@@ -1,3 +1,4 @@
+//go:build disgord_diagnosews
 // +build disgord_diagnosews
 
 package gateway

--- a/internal/gateway/eventclient_test.go
+++ b/internal/gateway/eventclient_test.go
@@ -1,3 +1,4 @@
+//go:build !integration
 // +build !integration
 
 package gateway

--- a/internal/gateway/metric_test.go
+++ b/internal/gateway/metric_test.go
@@ -1,3 +1,4 @@
+//go:build !integration
 // +build !integration
 
 package gateway

--- a/internal/gateway/packets.go
+++ b/internal/gateway/packets.go
@@ -67,11 +67,11 @@ type VoiceReady struct {
 }
 
 type voiceSelectProtocol struct {
-	Protocol string                     `json:"protocol"`
-	Data     *VoiceSelectProtocolParams `json:"data"`
+	Protocol string               `json:"protocol"`
+	Data     *VoiceSelectProtocol `json:"data"`
 }
 
-type VoiceSelectProtocolParams struct {
+type VoiceSelectProtocol struct {
 	Address string `json:"address"`
 	Port    uint16 `json:"port"`
 	Mode    string `json:"mode"`

--- a/internal/gateway/packets_disgordperf.go
+++ b/internal/gateway/packets_disgordperf.go
@@ -1,3 +1,4 @@
+//go:build disgordperf
 // +build disgordperf
 
 package gateway

--- a/internal/gateway/packets_disgordperf_test.go
+++ b/internal/gateway/packets_disgordperf_test.go
@@ -1,3 +1,4 @@
+//go:build disgordperf && !integration
 // +build disgordperf,!integration
 
 package gateway

--- a/internal/gateway/packets_test.go
+++ b/internal/gateway/packets_test.go
@@ -1,3 +1,4 @@
+//go:build !integration
 // +build !integration
 
 package gateway

--- a/internal/gateway/queue_test.go
+++ b/internal/gateway/queue_test.go
@@ -1,3 +1,4 @@
+//go:build !integration
 // +build !integration
 
 package gateway

--- a/internal/gateway/ratelimit_test.go
+++ b/internal/gateway/ratelimit_test.go
@@ -1,3 +1,4 @@
+//go:build !integration
 // +build !integration
 
 package gateway

--- a/internal/gateway/sharding_test.go
+++ b/internal/gateway/sharding_test.go
@@ -1,3 +1,4 @@
+//go:build !integration
 // +build !integration
 
 package gateway

--- a/internal/gateway/util_test.go
+++ b/internal/gateway/util_test.go
@@ -1,3 +1,4 @@
+//go:build !integration
 // +build !integration
 
 package gateway

--- a/internal/gateway/voiceclient.go
+++ b/internal/gateway/voiceclient.go
@@ -379,7 +379,7 @@ func sendVoiceIdentityPacket(m *VoiceClient) (err error) {
 	return
 }
 
-func (c *VoiceClient) SendUDPInfo(data *VoiceSelectProtocolParams) (ret *VoiceSessionDescription, err error) {
+func (c *VoiceClient) SendUDPInfo(data *VoiceSelectProtocol) (ret *VoiceSessionDescription, err error) {
 	ch := make(chan interface{}, 1)
 	c.onceChannels.Add(opcode.VoiceSessionDescription, ch)
 

--- a/internal/generate/events/cache.gohtml
+++ b/internal/generate/events/cache.gohtml
@@ -21,7 +21,7 @@ type CacheGetter interface {
     // REST API
 
     // GetGuildAuditLogs(guildID Snowflake) *guildAuditLogsBuilder // TODO
-    GetMessages(channelID Snowflake, params *GetMessagesParams) ([]*Message, error)
+    GetMessages(channelID Snowflake, params *GetMessages) ([]*Message, error)
     GetMessage(channelID, messageID Snowflake) (ret *Message, err error)
     //GetUsersWhoReacted(channelID, messageID Snowflake, emoji interface{}, params URLQueryStringer) (reactors []*User, err error)
     //GetPinnedMessages(channelID Snowflake) (ret []*Message, err error)
@@ -32,7 +32,7 @@ type CacheGetter interface {
     GetGuild(id Snowflake) (*Guild, error)
     GetGuildChannels(id Snowflake) ([]*Channel, error)
     GetMember(guildID, userID Snowflake) (*Member, error)
-    GetMembers(guildID Snowflake, params *GetMembersParams) ([]*Member, error)
+    GetMembers(guildID Snowflake, params *GetMembers) ([]*Member, error)
     //GetGuildBans(id Snowflake) ([]*Ban, error)
     //GetGuildBan(guildID, userID Snowflake) (*Ban, error)
     GetGuildRoles(guildID Snowflake) ([]*Role, error)
@@ -45,7 +45,7 @@ type CacheGetter interface {
     //GetInvite(inviteCode string, params URLQueryStringer) (*Invite, error)
     GetCurrentUser() (*User, error)
     GetUser(id Snowflake) (*User, error)
-    GetCurrentUserGuilds(params *GetCurrentUserGuildsParams) (ret []*Guild, err error)
+    GetCurrentUserGuilds(params *GetCurrentUserGuilds) (ret []*Guild, err error)
     //GetUserDMs() (ret []*Channel, err error)
     //GetUserConnections() (ret []*UserConnection, err error)
     //GetVoiceRegions() ([]*VoiceRegion, error)
@@ -117,12 +117,12 @@ func (c *CacheNop) GetMember(guildID, userID Snowflake) (*Member, error)        
 func (c *CacheNop) GetGuildRoles(guildID Snowflake) ([]*Role, error)            { return nil, CacheMissErr }
 func (c *CacheNop) GetCurrentUser() (*User, error)                              { return nil, CacheMissErr }
 func (c *CacheNop) GetUser(id Snowflake) (*User, error)                         { return nil, CacheMissErr }
-func (c *CacheNop) GetCurrentUserGuilds(p *GetCurrentUserGuildsParams) ([]*Guild, error) {
+func (c *CacheNop) GetCurrentUserGuilds(p *GetCurrentUserGuilds) ([]*Guild, error) {
     return nil, CacheMissErr
 }
-func (c *CacheNop) GetMessages(channel Snowflake, p *GetMessagesParams) ([]*Message, error) {
+func (c *CacheNop) GetMessages(channel Snowflake, p *GetMessages) ([]*Message, error) {
     return nil, CacheMissErr
 }
-func (c *CacheNop) GetMembers(guildID Snowflake, p *GetMembersParams) ([]*Member, error) {
+func (c *CacheNop) GetMembers(guildID Snowflake, p *GetMembers) ([]*Member, error) {
     return nil, CacheMissErr
 }

--- a/internal/generate/interfaces/main.go
+++ b/internal/generate/interfaces/main.go
@@ -57,9 +57,9 @@ func (f *fieldInfo) Resetable() bool {
 }
 
 type structInfo struct {
-	Name      string
-	ShortName string
-	Fields    []fieldInfo
+	Name          string
+	ShortName     string
+	Fields        []fieldInfo
 	NeededImports []importInfo
 }
 

--- a/internal/httd/bucket_test.go
+++ b/internal/httd/bucket_test.go
@@ -1,3 +1,4 @@
+//go:build !integration
 // +build !integration
 
 package httd

--- a/internal/httd/client_test.go
+++ b/internal/httd/client_test.go
@@ -1,3 +1,4 @@
+//go:build !integration
 // +build !integration
 
 package httd

--- a/internal/httd/ratelimit_test.go
+++ b/internal/httd/ratelimit_test.go
@@ -1,3 +1,4 @@
+//go:build !integration
 // +build !integration
 
 package httd

--- a/internal/httd/request_test.go
+++ b/internal/httd/request_test.go
@@ -1,3 +1,4 @@
+//go:build !integration
 // +build !integration
 
 package httd

--- a/internal/util/queue_test.go
+++ b/internal/util/queue_test.go
@@ -1,3 +1,4 @@
+//go:build !integration
 // +build !integration
 
 package util

--- a/invite.go
+++ b/invite.go
@@ -124,11 +124,11 @@ func (i inviteQueryBuilder) WithFlags(flags ...Flag) InviteQueryBuilder {
 	return &i
 }
 
-type getInviteParams struct {
+type getInviteQuery struct {
 	WithMemberCount bool `urlparam:"with_count,omitempty"`
 }
 
-var _ URLQueryStringer = (*getInviteParams)(nil)
+var _ URLQueryStringer = (*getInviteQuery)(nil)
 
 // Get [REST] Returns an invite object for the given code.
 //  Method                  GET
@@ -138,7 +138,7 @@ var _ URLQueryStringer = (*getInviteParams)(nil)
 //  Comment                 -
 //  withMemberCount: whether or not the invite should contain the approximate number of members
 func (i inviteQueryBuilder) Get(withMemberCount bool) (invite *Invite, err error) {
-	params := &getInviteParams{withMemberCount}
+	params := &getInviteQuery{withMemberCount}
 
 	r := i.client.newRESTRequest(&httd.Request{
 		Endpoint: endpoint.Invite(i.inviteCode) + params.URLQueryString(),

--- a/member.go
+++ b/member.go
@@ -18,7 +18,7 @@ type GuildMemberQueryBuilder interface {
 	AddRole(roleID Snowflake) error
 	RemoveRole(roleID Snowflake) error
 	Kick(reason string) error
-	Ban(params *BanMemberParams) error
+	Ban(params *BanMember) error
 	GetPermissions() (PermissionBit, error)
 }
 
@@ -134,7 +134,7 @@ func (g guildMemberQueryBuilder) Kick(reason string) error {
 
 // Ban Create a guild ban, and optionally delete previous messages sent by the banned user. Requires
 // the 'BAN_MEMBERS' permission. Returns a 204 empty response on success. Fires a Guild Ban Add Gateway event.
-func (g guildMemberQueryBuilder) Ban(params *BanMemberParams) (err error) {
+func (g guildMemberQueryBuilder) Ban(params *BanMember) (err error) {
 	if params == nil {
 		return errors.New("params was nil")
 	}

--- a/message.go
+++ b/message.go
@@ -267,7 +267,7 @@ func (m *Message) Send(ctx context.Context, s Session) (msg *Message, err error)
 	}
 
 	// TODO: attachments
-	params := &CreateMessageParams{
+	params := &CreateMessage{
 		Content:          m.Content,
 		Tts:              m.Tts,
 		MessageReference: m.MessageReference,

--- a/query_builders_nop_gen.go
+++ b/query_builders_nop_gen.go
@@ -63,19 +63,19 @@ func (c *channelQueryBuilderNop) CreateInvite() CreateChannelInviteBuilder {
 	return nil
 }
 
-func (c *channelQueryBuilderNop) CreateMessage(_ *CreateMessageParams) (*Message, error) {
+func (c *channelQueryBuilderNop) CreateMessage(_ *CreateMessage) (*Message, error) {
 	return nil, nil
 }
 
-func (c *channelQueryBuilderNop) CreateThread(_ Snowflake, _ *CreateThreadParams) (*Channel, error) {
+func (c *channelQueryBuilderNop) CreateThread(_ Snowflake, _ *CreateThread) (*Channel, error) {
 	return nil, nil
 }
 
-func (c *channelQueryBuilderNop) CreateThreadNoMessage(_ *CreateThreadParamsNoMessage) (*Channel, error) {
+func (c *channelQueryBuilderNop) CreateThreadNoMessage(_ *CreateThreadNoMessage) (*Channel, error) {
 	return nil, nil
 }
 
-func (c *channelQueryBuilderNop) CreateWebhook(_ *CreateWebhookParams) (*Webhook, error) {
+func (c *channelQueryBuilderNop) CreateWebhook(_ *CreateWebhook) (*Webhook, error) {
 	return nil, nil
 }
 
@@ -83,7 +83,7 @@ func (c *channelQueryBuilderNop) Delete() (*Channel, error) {
 	return nil, nil
 }
 
-func (c *channelQueryBuilderNop) DeleteMessages(_ *DeleteMessagesParams) error {
+func (c *channelQueryBuilderNop) DeleteMessages(_ *DeleteMessages) error {
 	return nil
 }
 
@@ -99,11 +99,11 @@ func (c *channelQueryBuilderNop) GetInvites() ([]*Invite, error) {
 	return nil, nil
 }
 
-func (c *channelQueryBuilderNop) GetJoinedPrivateArchivedThreads(_ *GetThreadsParams) (*ResponseBodyThreads, error) {
+func (c *channelQueryBuilderNop) GetJoinedPrivateArchivedThreads(_ *GetThreads) (*ResponseBodyThreads, error) {
 	return nil, nil
 }
 
-func (c *channelQueryBuilderNop) GetMessages(_ *GetMessagesParams) ([]*Message, error) {
+func (c *channelQueryBuilderNop) GetMessages(_ *GetMessages) ([]*Message, error) {
 	return nil, nil
 }
 
@@ -111,11 +111,11 @@ func (c *channelQueryBuilderNop) GetPinnedMessages() ([]*Message, error) {
 	return nil, nil
 }
 
-func (c *channelQueryBuilderNop) GetPrivateArchivedThreads(_ *GetThreadsParams) (*ResponseBodyThreads, error) {
+func (c *channelQueryBuilderNop) GetPrivateArchivedThreads(_ *GetThreads) (*ResponseBodyThreads, error) {
 	return nil, nil
 }
 
-func (c *channelQueryBuilderNop) GetPublicArchivedThreads(_ *GetThreadsParams) (*ResponseBodyThreads, error) {
+func (c *channelQueryBuilderNop) GetPublicArchivedThreads(_ *GetThreads) (*ResponseBodyThreads, error) {
 	return nil, nil
 }
 
@@ -159,7 +159,7 @@ func (c *channelQueryBuilderNop) UpdateBuilder() UpdateChannelBuilder {
 	return nil
 }
 
-func (c *channelQueryBuilderNop) UpdatePermissions(_ Snowflake, _ *UpdateChannelPermissionsParams) error {
+func (c *channelQueryBuilderNop) UpdatePermissions(_ Snowflake, _ *UpdateChannelPermissions) error {
 	return nil
 }
 
@@ -195,7 +195,7 @@ func (c *clientQueryBuilderNop) Channel(_ Snowflake) ChannelQueryBuilder {
 	return nil
 }
 
-func (c *clientQueryBuilderNop) CreateGuild(_ string, _ *CreateGuildParams) (*Guild, error) {
+func (c *clientQueryBuilderNop) CreateGuild(_ string, _ *CreateGuild) (*Guild, error) {
 	return nil, nil
 }
 
@@ -247,7 +247,7 @@ func (c currentUserQueryBuilderNop) WithFlags(flags ...Flag) CurrentUserQueryBui
 	return &c
 }
 
-func (c *currentUserQueryBuilderNop) CreateGroupDM(_ *CreateGroupDMParams) (*Channel, error) {
+func (c *currentUserQueryBuilderNop) CreateGroupDM(_ *CreateGroupDM) (*Channel, error) {
 	return nil, nil
 }
 
@@ -255,7 +255,7 @@ func (c *currentUserQueryBuilderNop) Get() (*User, error) {
 	return nil, nil
 }
 
-func (c *currentUserQueryBuilderNop) GetGuilds(_ *GetCurrentUserGuildsParams) ([]*Guild, error) {
+func (c *currentUserQueryBuilderNop) GetGuilds(_ *GetCurrentUserGuilds) ([]*Guild, error) {
 	return nil, nil
 }
 
@@ -730,7 +730,7 @@ func (g *guildMemberQueryBuilderNop) AddRole(_ Snowflake) error {
 	return nil
 }
 
-func (g *guildMemberQueryBuilderNop) Ban(_ *BanMemberParams) error {
+func (g *guildMemberQueryBuilderNop) Ban(_ *BanMember) error {
 	return nil
 }
 
@@ -774,23 +774,23 @@ func (g guildQueryBuilderNop) WithFlags(flags ...Flag) GuildQueryBuilder {
 	return &g
 }
 
-func (g *guildQueryBuilderNop) CreateChannel(_ string, _ *CreateGuildChannelParams) (*Channel, error) {
+func (g *guildQueryBuilderNop) CreateChannel(_ string, _ *CreateGuildChannel) (*Channel, error) {
 	return nil, nil
 }
 
-func (g *guildQueryBuilderNop) CreateEmoji(_ *CreateGuildEmojiParams) (*Emoji, error) {
+func (g *guildQueryBuilderNop) CreateEmoji(_ *CreateGuildEmoji) (*Emoji, error) {
 	return nil, nil
 }
 
-func (g *guildQueryBuilderNop) CreateIntegration(_ *CreateGuildIntegrationParams) error {
+func (g *guildQueryBuilderNop) CreateIntegration(_ *CreateGuildIntegration) error {
 	return nil
 }
 
-func (g *guildQueryBuilderNop) CreateMember(_ Snowflake, _ string, _ *AddGuildMemberParams) (*Member, error) {
+func (g *guildQueryBuilderNop) CreateMember(_ Snowflake, _ string, _ *AddGuildMember) (*Member, error) {
 	return nil, nil
 }
 
-func (g *guildQueryBuilderNop) CreateRole(_ *CreateGuildRoleParams) (*Role, error) {
+func (g *guildQueryBuilderNop) CreateRole(_ *CreateGuildRole) (*Role, error) {
 	return nil, nil
 }
 
@@ -850,7 +850,7 @@ func (g *guildQueryBuilderNop) GetInvites() ([]*Invite, error) {
 	return nil, nil
 }
 
-func (g *guildQueryBuilderNop) GetMembers(_ *GetMembersParams) ([]*Member, error) {
+func (g *guildQueryBuilderNop) GetMembers(_ *GetMembers) ([]*Member, error) {
 	return nil, nil
 }
 
@@ -902,7 +902,7 @@ func (g *guildQueryBuilderNop) UpdateBuilder() UpdateGuildBuilder {
 	return nil
 }
 
-func (g *guildQueryBuilderNop) UpdateChannelPositions(_ []UpdateGuildChannelPositionsParams) error {
+func (g *guildQueryBuilderNop) UpdateChannelPositions(_ []UpdateGuildChannelPositions) error {
 	return nil
 }
 
@@ -910,11 +910,11 @@ func (g *guildQueryBuilderNop) UpdateEmbedBuilder() UpdateGuildEmbedBuilder {
 	return nil
 }
 
-func (g *guildQueryBuilderNop) UpdateIntegration(_ Snowflake, _ *UpdateGuildIntegrationParams) error {
+func (g *guildQueryBuilderNop) UpdateIntegration(_ Snowflake, _ *UpdateGuildIntegration) error {
 	return nil
 }
 
-func (g *guildQueryBuilderNop) UpdateRolePositions(_ []UpdateGuildRolePositionsParams) ([]*Role, error) {
+func (g *guildQueryBuilderNop) UpdateRolePositions(_ []UpdateGuildRolePositions) ([]*Role, error) {
 	return nil, nil
 }
 
@@ -1154,7 +1154,7 @@ func (v *voiceChannelQueryBuilderNop) UpdateBuilder() UpdateChannelBuilder {
 	return nil
 }
 
-func (v *voiceChannelQueryBuilderNop) UpdatePermissions(_ Snowflake, _ *UpdateChannelPermissionsParams) error {
+func (v *voiceChannelQueryBuilderNop) UpdatePermissions(_ Snowflake, _ *UpdateChannelPermissions) error {
 	return nil
 }
 
@@ -1182,15 +1182,15 @@ func (w *webhookQueryBuilderNop) Delete() error {
 	return nil
 }
 
-func (w *webhookQueryBuilderNop) Execute(_ *ExecuteWebhookParams, _ bool, _ Snowflake, _ string) (*Message, error) {
+func (w *webhookQueryBuilderNop) Execute(_ *ExecuteWebhook, _ bool, _ Snowflake, _ string) (*Message, error) {
 	return nil, nil
 }
 
-func (w *webhookQueryBuilderNop) ExecuteGitHubWebhook(_ *ExecuteWebhookParams, _ bool, _ Snowflake) (*Message, error) {
+func (w *webhookQueryBuilderNop) ExecuteGitHubWebhook(_ *ExecuteWebhook, _ bool, _ Snowflake) (*Message, error) {
 	return nil, nil
 }
 
-func (w *webhookQueryBuilderNop) ExecuteSlackWebhook(_ *ExecuteWebhookParams, _ bool, _ Snowflake) (*Message, error) {
+func (w *webhookQueryBuilderNop) ExecuteSlackWebhook(_ *ExecuteWebhook, _ bool, _ Snowflake) (*Message, error) {
 	return nil, nil
 }
 
@@ -1230,7 +1230,7 @@ func (w *webhookWithTokenQueryBuilderNop) Delete() error {
 	return nil
 }
 
-func (w *webhookWithTokenQueryBuilderNop) Execute(_ *ExecuteWebhookParams, _ bool, _ Snowflake, _ string) (*Message, error) {
+func (w *webhookWithTokenQueryBuilderNop) Execute(_ *ExecuteWebhook, _ bool, _ Snowflake, _ string) (*Message, error) {
 	return nil, nil
 }
 

--- a/reaction.go
+++ b/reaction.go
@@ -196,14 +196,14 @@ func (r reactionQueryBuilder) DeleteUser(userID Snowflake) error {
 	return err
 }
 
-// GetReactionURLParams https://discord.com/developers/docs/resources/channel#get-reactions-query-string-params
-type GetReactionURLParams struct {
+// GetReactionURL https://discord.com/developers/docs/resources/channel#get-reactions-query-string-params
+type GetReactionURL struct {
 	Before Snowflake `urlparam:"before,omitempty"` // get Users before this user Snowflake
 	After  Snowflake `urlparam:"after,omitempty"`  // get Users after this user Snowflake
 	Limit  int       `urlparam:"limit,omitempty"`  // max number of Users to return (1-100)
 }
 
-var _ URLQueryStringer = (*GetReactionURLParams)(nil)
+var _ URLQueryStringer = (*GetReactionURL)(nil)
 
 // Get [REST] Get a list of Users that reacted with this emoji. Returns an array of user objects on success.
 //  Method                  GET

--- a/rest.go
+++ b/rest.go
@@ -317,7 +317,7 @@ type basicBuilder struct {
 
 type ClientQueryBuilderExecutables interface {
 	// CreateGuild Create a new guild. Returns a guild object on success. Fires a Guild Create Gateway event.
-	CreateGuild(guildName string, params *CreateGuildParams) (*Guild, error)
+	CreateGuild(guildName string, params *CreateGuild) (*Guild, error)
 
 	// GetVoiceRegions Returns an array of voice region objects that can be used when creating servers.
 	GetVoiceRegions() ([]*VoiceRegion, error)
@@ -368,9 +368,9 @@ func (c clientQueryBuilder) WithContextAndFlags(ctx context.Context, flags ...Fl
 // does not have an ID, the Message will populate a CreateMessage with it's fields.
 //
 // If you want to affect the actual message data besides .Content; provide a
-// MessageCreateParams. The reply message will be updated by the last one provided.
+// MessageCreate. The reply message will be updated by the last one provided.
 func (c clientQueryBuilder) SendMsg(channelID Snowflake, data ...interface{}) (msg *Message, err error) {
-	params := &CreateMessageParams{}
+	params := &CreateMessage{}
 	addEmbed := func(e *Embed) error {
 		if params.Embed != nil {
 			return errors.New("can only send one embed")
@@ -405,13 +405,13 @@ func (c clientQueryBuilder) SendMsg(channelID Snowflake, data ...interface{}) (m
 
 		var s string
 		switch t := data[i].(type) {
-		case *CreateMessageParams:
+		case *CreateMessage:
 			*params = *t
-		case CreateMessageParams:
+		case CreateMessage:
 			*params = t
-		case CreateMessageFileParams:
+		case CreateMessageFile:
 			params.Files = append(params.Files, t)
-		case *CreateMessageFileParams:
+		case *CreateMessageFile:
 			params.Files = append(params.Files, *t)
 		case Embed:
 			if err = addEmbed(&t); err != nil {
@@ -422,7 +422,7 @@ func (c clientQueryBuilder) SendMsg(channelID Snowflake, data ...interface{}) (m
 				return nil, err
 			}
 		case *os.File:
-			return nil, errors.New("can not handle *os.File, use a CreateMessageFileParams instead")
+			return nil, errors.New("can not handle *os.File, use a CreateMessageFile instead")
 		case string:
 			s = t
 		case Message:

--- a/sort_gen.go
+++ b/sort_gen.go
@@ -83,17 +83,17 @@ func derefSliceP(v interface{}) (s interface{}) {
 		s = *t
 	case *[]*Channel:
 		s = *t
-	case *[]*CreateMessageFileParams:
+	case *[]*CreateMessage:
 		s = *t
-	case *[]*CreateMessageParams:
+	case *[]*CreateMessageFile:
 		s = *t
-	case *[]*CreateWebhookParams:
+	case *[]*CreateWebhook:
 		s = *t
-	case *[]*DeleteMessagesParams:
+	case *[]*DeleteMessages:
 		s = *t
-	case *[]*GetMessagesParams:
+	case *[]*GetMessages:
 		s = *t
-	case *[]*GetThreadsParams:
+	case *[]*GetThreads:
 		s = *t
 	case *[]*GroupDMParticipant:
 		s = *t
@@ -103,7 +103,7 @@ func derefSliceP(v interface{}) (s interface{}) {
 		s = *t
 	case *[]*ResponseBodyThreads:
 		s = *t
-	case *[]*UpdateChannelPermissionsParams:
+	case *[]*UpdateChannelPermissions:
 		s = *t
 	case *[]*Client:
 		s = *t
@@ -217,23 +217,23 @@ func derefSliceP(v interface{}) (s interface{}) {
 		s = *t
 	case *[]*WebhooksUpdate:
 		s = *t
-	case *[]*AddGuildMemberParams:
+	case *[]*AddGuildMember:
 		s = *t
 	case *[]*Ban:
 		s = *t
-	case *[]*BanMemberParams:
+	case *[]*BanMember:
 		s = *t
-	case *[]*CreateGuildChannelParams:
+	case *[]*CreateGuild:
 		s = *t
-	case *[]*CreateGuildEmojiParams:
+	case *[]*CreateGuildChannel:
 		s = *t
-	case *[]*CreateGuildIntegrationParams:
+	case *[]*CreateGuildEmoji:
 		s = *t
-	case *[]*CreateGuildParams:
+	case *[]*CreateGuildIntegration:
 		s = *t
-	case *[]*CreateGuildRoleParams:
+	case *[]*CreateGuildRole:
 		s = *t
-	case *[]*GetMembersParams:
+	case *[]*GetMembers:
 		s = *t
 	case *[]*Guild:
 		s = *t
@@ -251,11 +251,11 @@ func derefSliceP(v interface{}) (s interface{}) {
 		s = *t
 	case *[]*ResponseBodyGuildThreads:
 		s = *t
-	case *[]*UpdateGuildChannelPositionsParams:
+	case *[]*UpdateGuildChannelPositions:
 		s = *t
-	case *[]*UpdateGuildIntegrationParams:
+	case *[]*UpdateGuildIntegration:
 		s = *t
-	case *[]*UpdateGuildRolePositionsParams:
+	case *[]*UpdateGuildRolePositions:
 		s = *t
 	case *[]*ApplicationCommandInteractionData:
 		s = *t
@@ -287,7 +287,7 @@ func derefSliceP(v interface{}) (s interface{}) {
 		s = *t
 	case *[]*StickerItem:
 		s = *t
-	case *[]*GetReactionURLParams:
+	case *[]*GetReactionURL:
 		s = *t
 	case *[]*Reaction:
 		s = *t
@@ -301,9 +301,9 @@ func derefSliceP(v interface{}) (s interface{}) {
 		s = *t
 	case *[]*Time:
 		s = *t
-	case *[]*CreateThreadParams:
+	case *[]*CreateThread:
 		s = *t
-	case *[]*CreateThreadParamsNoMessage:
+	case *[]*CreateThreadNoMessage:
 		s = *t
 	case *[]*ThreadMember:
 		s = *t
@@ -323,9 +323,9 @@ func derefSliceP(v interface{}) (s interface{}) {
 		s = *t
 	case *[]*ClientStatus:
 		s = *t
-	case *[]*CreateGroupDMParams:
+	case *[]*CreateGroupDM:
 		s = *t
-	case *[]*GetCurrentUserGuildsParams:
+	case *[]*GetCurrentUserGuilds:
 		s = *t
 	case *[]*User:
 		s = *t
@@ -337,7 +337,7 @@ func derefSliceP(v interface{}) (s interface{}) {
 		s = *t
 	case *[]*VoiceState:
 		s = *t
-	case *[]*ExecuteWebhookParams:
+	case *[]*ExecuteWebhook:
 		s = *t
 	case *[]*Webhook:
 		s = *t
@@ -429,7 +429,7 @@ func sortByID(v interface{}, flags Flag) {
 		} else {
 			less = func(i, j int) bool { return s[i].ID < s[j].ID }
 		}
-	case []*CreateGuildIntegrationParams:
+	case []*CreateGuildIntegration:
 		if descending {
 			less = func(i, j int) bool { return s[i].ID > s[j].ID }
 		} else {
@@ -459,13 +459,13 @@ func sortByID(v interface{}, flags Flag) {
 		} else {
 			less = func(i, j int) bool { return s[i].ID < s[j].ID }
 		}
-	case []*UpdateGuildChannelPositionsParams:
+	case []*UpdateGuildChannelPositions:
 		if descending {
 			less = func(i, j int) bool { return s[i].ID > s[j].ID }
 		} else {
 			less = func(i, j int) bool { return s[i].ID < s[j].ID }
 		}
-	case []*UpdateGuildRolePositionsParams:
+	case []*UpdateGuildRolePositions:
 		if descending {
 			less = func(i, j int) bool { return s[i].ID > s[j].ID }
 		} else {
@@ -933,7 +933,7 @@ func sortByName(v interface{}, flags Flag) {
 		} else {
 			less = func(i, j int) bool { return strings.ToLower(s[i].Name) < strings.ToLower(s[j].Name) }
 		}
-	case []*CreateWebhookParams:
+	case []*CreateWebhook:
 		if descending {
 			less = func(i, j int) bool { return strings.ToLower(s[i].Name) > strings.ToLower(s[j].Name) }
 		} else {
@@ -969,25 +969,25 @@ func sortByName(v interface{}, flags Flag) {
 		} else {
 			less = func(i, j int) bool { return strings.ToLower(s[i].Name) < strings.ToLower(s[j].Name) }
 		}
-	case []*CreateGuildChannelParams:
+	case []*CreateGuild:
 		if descending {
 			less = func(i, j int) bool { return strings.ToLower(s[i].Name) > strings.ToLower(s[j].Name) }
 		} else {
 			less = func(i, j int) bool { return strings.ToLower(s[i].Name) < strings.ToLower(s[j].Name) }
 		}
-	case []*CreateGuildEmojiParams:
+	case []*CreateGuildChannel:
 		if descending {
 			less = func(i, j int) bool { return strings.ToLower(s[i].Name) > strings.ToLower(s[j].Name) }
 		} else {
 			less = func(i, j int) bool { return strings.ToLower(s[i].Name) < strings.ToLower(s[j].Name) }
 		}
-	case []*CreateGuildParams:
+	case []*CreateGuildEmoji:
 		if descending {
 			less = func(i, j int) bool { return strings.ToLower(s[i].Name) > strings.ToLower(s[j].Name) }
 		} else {
 			less = func(i, j int) bool { return strings.ToLower(s[i].Name) < strings.ToLower(s[j].Name) }
 		}
-	case []*CreateGuildRoleParams:
+	case []*CreateGuildRole:
 		if descending {
 			less = func(i, j int) bool { return strings.ToLower(s[i].Name) > strings.ToLower(s[j].Name) }
 		} else {
@@ -1053,13 +1053,13 @@ func sortByName(v interface{}, flags Flag) {
 		} else {
 			less = func(i, j int) bool { return strings.ToLower(s[i].Name) < strings.ToLower(s[j].Name) }
 		}
-	case []*CreateThreadParams:
+	case []*CreateThread:
 		if descending {
 			less = func(i, j int) bool { return strings.ToLower(s[i].Name) > strings.ToLower(s[j].Name) }
 		} else {
 			less = func(i, j int) bool { return strings.ToLower(s[i].Name) < strings.ToLower(s[j].Name) }
 		}
-	case []*CreateThreadParamsNoMessage:
+	case []*CreateThreadNoMessage:
 		if descending {
 			less = func(i, j int) bool { return strings.ToLower(s[i].Name) > strings.ToLower(s[j].Name) }
 		} else {
@@ -1111,7 +1111,7 @@ func sortByHoist(v interface{}, flags Flag) {
 
 	var less func(i, j int) bool
 	switch s := v.(type) {
-	case []*CreateGuildRoleParams:
+	case []*CreateGuildRole:
 		if descending {
 			less = func(i, j int) bool { return s[i].Hoist && !s[j].Hoist }
 		} else {

--- a/std/msgfilter_test.go
+++ b/std/msgfilter_test.go
@@ -1,3 +1,4 @@
+//go:build !integration
 // +build !integration
 
 package std

--- a/thread.go
+++ b/thread.go
@@ -29,7 +29,7 @@ const (
 )
 
 // ref https://discord.com/developers/docs/resources/channel#start-thread-with-message-json-params
-type CreateThreadParams struct {
+type CreateThread struct {
 	Name                string                  `json:"name"`
 	AutoArchiveDuration AutoArchiveDurationTime `json:"auto_archive_duration,omitempty"`
 	RateLimitPerUser    int                     `json:"rate_limit_per_user,omitempty"`
@@ -39,7 +39,7 @@ type CreateThreadParams struct {
 }
 
 // ref https://discord.com/developers/docs/resources/channel#start-thread-without-message-json-params
-type CreateThreadParamsNoMessage struct {
+type CreateThreadNoMessage struct {
 	Name                string                  `json:"name"`
 	AutoArchiveDuration AutoArchiveDurationTime `json:"auto_archive_duration,omitempty"`
 	// In API v9, type defaults to PRIVATE_THREAD in order to match the behavior when

--- a/thread_integration_test.go
+++ b/thread_integration_test.go
@@ -35,11 +35,11 @@ func TestThreadEndpoints(t *testing.T) {
 		func() {
 			defer wg.Done()
 			threadName := "HELLO WORLD1"
-			msg, err := c.Channel(guildTypical.TextChannelGeneral).WithContext(deadline).CreateMessage(&CreateMessageParams{Content: threadName})
+			msg, err := c.Channel(guildTypical.TextChannelGeneral).WithContext(deadline).CreateMessage(&CreateMessage{Content: threadName})
 			if err != nil {
 				panic(err)
 			}
-			thread, err := c.Channel(guildTypical.TextChannelGeneral).WithContext(deadline).CreateThread(msg.ID, &CreateThreadParams{
+			thread, err := c.Channel(guildTypical.TextChannelGeneral).WithContext(deadline).CreateThread(msg.ID, &CreateThread{
 				Name:                threadName,
 				AutoArchiveDuration: AutoArchiveThreadDay,
 			})
@@ -62,7 +62,7 @@ func TestThreadEndpoints(t *testing.T) {
 		func() {
 			defer wg.Done()
 			threadName := "HELLO WORLD2"
-			thread, err := c.Channel(guildTypical.TextChannelGeneral).WithContext(deadline).CreateThreadNoMessage(&CreateThreadParamsNoMessage{
+			thread, err := c.Channel(guildTypical.TextChannelGeneral).WithContext(deadline).CreateThreadNoMessage(&CreateThreadNoMessage{
 				Name:                threadName,
 				AutoArchiveDuration: AutoArchiveThreadDay,
 				Type:                ChannelTypeGuildPublicThread,
@@ -87,7 +87,7 @@ func TestThreadEndpoints(t *testing.T) {
 		func() {
 			defer wg.Done()
 			threadName := "HELLO WORLD3"
-			thread, err := c.Channel(guildTypical.TextChannelGeneral).WithContext(deadline).CreateThreadNoMessage(&CreateThreadParamsNoMessage{
+			thread, err := c.Channel(guildTypical.TextChannelGeneral).WithContext(deadline).CreateThreadNoMessage(&CreateThreadNoMessage{
 				Name:                threadName,
 				AutoArchiveDuration: AutoArchiveThreadDay,
 				Type:                ChannelTypeGuildPublicThread,
@@ -111,7 +111,7 @@ func TestThreadEndpoints(t *testing.T) {
 		func() {
 			defer wg.Done()
 			threadName := "HELLO WORLD4"
-			thread, err := c.Channel(guildTypical.TextChannelGeneral).WithContext(deadline).CreateThreadNoMessage(&CreateThreadParamsNoMessage{
+			thread, err := c.Channel(guildTypical.TextChannelGeneral).WithContext(deadline).CreateThreadNoMessage(&CreateThreadNoMessage{
 				Name:                threadName,
 				AutoArchiveDuration: AutoArchiveThreadDay,
 				Type:                ChannelTypeGuildPublicThread,
@@ -139,7 +139,7 @@ func TestThreadEndpoints(t *testing.T) {
 		func() {
 			defer wg.Done()
 			threadName := "HELLO WORLD5"
-			thread, err := c.Channel(guildTypical.TextChannelGeneral).WithContext(deadline).CreateThreadNoMessage(&CreateThreadParamsNoMessage{
+			thread, err := c.Channel(guildTypical.TextChannelGeneral).WithContext(deadline).CreateThreadNoMessage(&CreateThreadNoMessage{
 				Name:                threadName,
 				AutoArchiveDuration: AutoArchiveThreadDay,
 				Type:                ChannelTypeGuildPublicThread,
@@ -163,7 +163,7 @@ func TestThreadEndpoints(t *testing.T) {
 		func() {
 			defer wg.Done()
 			threadName := "HELLO WORLD6"
-			thread, err := c.Channel(guildTypical.TextChannelGeneral).WithContext(deadline).CreateThreadNoMessage(&CreateThreadParamsNoMessage{
+			thread, err := c.Channel(guildTypical.TextChannelGeneral).WithContext(deadline).CreateThreadNoMessage(&CreateThreadNoMessage{
 				Name:                threadName,
 				AutoArchiveDuration: AutoArchiveThreadDay,
 				Type:                ChannelTypeGuildPublicThread,
@@ -191,7 +191,7 @@ func TestThreadEndpoints(t *testing.T) {
 		func() {
 			defer wg.Done()
 			threadName := "HELLO WORLD7"
-			thread, err := c.Channel(guildTypical.TextChannelGeneral).WithContext(deadline).CreateThreadNoMessage(&CreateThreadParamsNoMessage{
+			thread, err := c.Channel(guildTypical.TextChannelGeneral).WithContext(deadline).CreateThreadNoMessage(&CreateThreadNoMessage{
 				Name:                threadName,
 				AutoArchiveDuration: AutoArchiveThreadDay,
 				Type:                ChannelTypeGuildPublicThread,
@@ -221,7 +221,7 @@ func TestThreadEndpoints(t *testing.T) {
 		func() {
 			defer wg.Done()
 			threadName := "HELLO WORLD8"
-			thread, err := c.Channel(guildTypical.TextChannelGeneral).WithContext(deadline).CreateThreadNoMessage(&CreateThreadParamsNoMessage{
+			thread, err := c.Channel(guildTypical.TextChannelGeneral).WithContext(deadline).CreateThreadNoMessage(&CreateThreadNoMessage{
 				Name:                threadName,
 				AutoArchiveDuration: AutoArchiveThreadDay,
 				Type:                ChannelTypeGuildPublicThread,

--- a/user.go
+++ b/user.go
@@ -400,7 +400,7 @@ type CurrentUserQueryBuilder interface {
 
 	// GetGuilds Returns a list of partial guild objects the current user is a member of.
 	// Requires the Guilds OAuth2 scope.
-	GetGuilds(params *GetCurrentUserGuildsParams) (ret []*Guild, err error)
+	GetGuilds(params *GetCurrentUserGuilds) (ret []*Guild, err error)
 
 	// LeaveGuild Leave a guild. Returns a 204 empty response on success.
 	LeaveGuild(id Snowflake) (err error)
@@ -408,7 +408,7 @@ type CurrentUserQueryBuilder interface {
 	// CreateGroupDM Create a new group DM channel with multiple Users. Returns a DM channel object.
 	// This endpoint was intended to be used with the now-deprecated GameBridge SDK. DMs created with this
 	// endpoint will not be shown in the Discord Client
-	CreateGroupDM(params *CreateGroupDMParams) (ret *Channel, err error)
+	CreateGroupDM(params *CreateGroupDM) (ret *Channel, err error)
 
 	// GetUserConnections Returns a list of connection objects. Requires the connections OAuth2 scope.
 	GetUserConnections() (ret []*UserConnection, err error)
@@ -484,14 +484,14 @@ func (c currentUserQueryBuilder) UpdateBuilder() UpdateCurrentUserBuilder {
 	return builder
 }
 
-// GetCurrentUserGuildsParams JSON params for func GetCurrentUserGuilds
-type GetCurrentUserGuildsParams struct {
+// GetCurrentUserGuilds JSON params for func GetCurrentUserGuilds
+type GetCurrentUserGuilds struct {
 	Before Snowflake `urlparam:"before,omitempty"`
 	After  Snowflake `urlparam:"after,omitempty"`
 	Limit  int       `urlparam:"limit,omitempty"`
 }
 
-var _ URLQueryStringer = (*GetCurrentUserGuildsParams)(nil)
+var _ URLQueryStringer = (*GetCurrentUserGuilds)(nil)
 
 // GetGuilds [REST] Returns a list of partial guild objects the current user is a member of.
 // Requires the Guilds OAuth2 scope.
@@ -502,7 +502,7 @@ var _ URLQueryStringer = (*GetCurrentUserGuildsParams)(nil)
 //  Comment                 This endpoint. returns 100 Guilds by default, which is the maximum number of
 //                          Guilds a non-bot user can join. Therefore, pagination is not needed for
 //                          integrations that need to get a list of Users' Guilds.
-func (c currentUserQueryBuilder) GetGuilds(params *GetCurrentUserGuildsParams) (ret []*Guild, err error) {
+func (c currentUserQueryBuilder) GetGuilds(params *GetCurrentUserGuilds) (ret []*Guild, err error) {
 	r := c.client.newRESTRequest(&httd.Request{
 		Endpoint: endpoint.UserMeGuilds(),
 		Ctx:      c.ctx,
@@ -523,9 +523,9 @@ func (c currentUserQueryBuilder) GetGuilds(params *GetCurrentUserGuildsParams) (
 	return nil, errors.New("unable to cast guild slice")
 }
 
-// CreateGroupDMParams required JSON params for func CreateGroupDM
+// CreateGroupDM required JSON params for func CreateGroupDM
 // https://discord.com/developers/docs/resources/user#create-group-dm
-type CreateGroupDMParams struct {
+type CreateGroupDM struct {
 	// AccessTokens access tokens of Users that have granted your app the gdm.join scope
 	AccessTokens []string `json:"access_tokens"`
 
@@ -558,7 +558,7 @@ func (c currentUserQueryBuilder) LeaveGuild(id Snowflake) (err error) {
 //  Discord documentation   https://discord.com/developers/docs/resources/user#create-group-dm
 //  Reviewed                2019-02-19
 //  Comment                 -
-func (c currentUserQueryBuilder) CreateGroupDM(params *CreateGroupDMParams) (ret *Channel, err error) {
+func (c currentUserQueryBuilder) CreateGroupDM(params *CreateGroupDM) (ret *Channel, err error) {
 	r := c.client.newRESTRequest(&httd.Request{
 		Method:      http.MethodPost,
 		Ctx:         c.ctx,

--- a/user_test.go
+++ b/user_test.go
@@ -30,7 +30,7 @@ func TestUserPresence_InterfaceImplementations(t *testing.T) {
 	})
 }
 
-func TestGetCurrentUserGuildsParams(t *testing.T) {
+func TestGetCurrentUserGuilds(t *testing.T) {
 	params := &getCurrentUserGuildsBuilder{}
 	params.r.setup(nil, nil, nil)
 	var wants string

--- a/voice.go
+++ b/voice.go
@@ -152,7 +152,7 @@ type VoiceChannelQueryBuilder interface {
 	// UpdatePermissions Edit the channel permission overwrites for a user or role in a channel. Only usable
 	// for guild Channels. Requires the 'MANAGE_ROLES' permission. Returns a 204 empty response on success.
 	// For more information about permissions, see permissions.
-	UpdatePermissions(overwriteID Snowflake, params *UpdateChannelPermissionsParams) error
+	UpdatePermissions(overwriteID Snowflake, params *UpdateChannelPermissions) error
 
 	// GetInvites Returns a list of invite objects (with invite metadata) for the channel. Only usable for
 	// guild Channels. Requires the 'MANAGE_CHANNELS' permission.

--- a/voiceconnection.go
+++ b/voiceconnection.go
@@ -225,7 +225,7 @@ waiter:
 	// libSodium/NaCl and golang.org/x/crypto/nacl/secretbox use. If both Discord and Go both start supporting more
 	// modes "out of the box" we might want to consider implementing a "preferred mode selection" algorithm here.
 	var session *gateway.VoiceSessionDescription
-	session, err = voice.ws.SendUDPInfo(&gateway.VoiceSelectProtocolParams{
+	session, err = voice.ws.SendUDPInfo(&gateway.VoiceSelectProtocol{
 		Mode:    "xsalsa20_poly1305",
 		Address: ip,
 		Port:    port,

--- a/webhook.go
+++ b/webhook.go
@@ -45,13 +45,13 @@ type WebhookQueryBuilder interface {
 	Delete() error
 
 	// Execute Trigger a webhook in Discord.
-	Execute(params *ExecuteWebhookParams, wait bool, threadID Snowflake, URLSuffix string) (*Message, error)
+	Execute(params *ExecuteWebhook, wait bool, threadID Snowflake, URLSuffix string) (*Message, error)
 
 	// ExecuteSlackWebhook Trigger a webhook in Discord from the Slack app.
-	ExecuteSlackWebhook(params *ExecuteWebhookParams, wait bool, threadID Snowflake) (*Message, error)
+	ExecuteSlackWebhook(params *ExecuteWebhook, wait bool, threadID Snowflake) (*Message, error)
 
 	// ExecuteGitHubWebhook Trigger a webhook in Discord from the GitHub app.
-	ExecuteGitHubWebhook(params *ExecuteWebhookParams, wait bool, threadID Snowflake) (*Message, error)
+	ExecuteGitHubWebhook(params *ExecuteWebhook, wait bool, threadID Snowflake) (*Message, error)
 
 	WithToken(token string) WebhookWithTokenQueryBuilder
 }
@@ -130,8 +130,8 @@ func (w webhookQueryBuilder) Delete() (err error) {
 	return w.WithToken("").WithFlags(w.flags).WithContext(w.ctx).Delete()
 }
 
-// ExecuteWebhookParams JSON params for func ExecuteWebhook
-type ExecuteWebhookParams struct {
+// ExecuteWebhook JSON params for func ExecuteWebhook
+type ExecuteWebhook struct {
 	Content   string      `json:"content"`
 	Username  string      `json:"username"`
 	AvatarURL string      `json:"avatar_url"`
@@ -140,15 +140,15 @@ type ExecuteWebhookParams struct {
 	Embeds    []*Embed    `json:"embeds"`
 }
 
-type execWebhookParams struct {
+type execWebhook struct {
 	Wait     bool      `urlparam:"wait"`
 	ThreadID Snowflake `urlparam:"thread_id"`
 }
 
-var _ URLQueryStringer = (*execWebhookParams)(nil)
+var _ URLQueryStringer = (*execWebhook)(nil)
 
 // Execute Trigger a webhook in Discord.
-func (w webhookQueryBuilder) Execute(params *ExecuteWebhookParams, wait bool, threadID Snowflake, URLSuffix string) (message *Message, err error) {
+func (w webhookQueryBuilder) Execute(params *ExecuteWebhook, wait bool, threadID Snowflake, URLSuffix string) (message *Message, err error) {
 	return w.WithToken("").WithFlags(w.flags).WithContext(w.ctx).Execute(params, wait, threadID, URLSuffix)
 }
 
@@ -159,7 +159,7 @@ func (w webhookQueryBuilder) Execute(params *ExecuteWebhookParams, wait bool, th
 //  Reviewed                2020-05-21
 //  Comment                 Refer to Slack's documentation for more information. We do not support Slack's channel,
 //                          icon_emoji, mrkdwn, or mrkdwn_in properties.
-func (w webhookQueryBuilder) ExecuteSlackWebhook(params *ExecuteWebhookParams, wait bool, threadID Snowflake) (message *Message, err error) {
+func (w webhookQueryBuilder) ExecuteSlackWebhook(params *ExecuteWebhook, wait bool, threadID Snowflake) (message *Message, err error) {
 	return w.WithToken("").WithFlags(w.flags).WithContext(w.ctx).Execute(params, wait, threadID, endpoint.Slack())
 }
 
@@ -172,7 +172,7 @@ func (w webhookQueryBuilder) ExecuteSlackWebhook(params *ExecuteWebhookParams, w
 //                          as the "Payload URL." You can choose what events your Discord channel receives by
 //                          choosing the "Let me select individual events" option and selecting individual
 //                          events for the new webhook you're configuring.
-func (w webhookQueryBuilder) ExecuteGitHubWebhook(params *ExecuteWebhookParams, wait bool, threadID Snowflake) (message *Message, err error) {
+func (w webhookQueryBuilder) ExecuteGitHubWebhook(params *ExecuteWebhook, wait bool, threadID Snowflake) (message *Message, err error) {
 	return w.WithToken("").WithFlags(w.flags).WithContext(w.ctx).Execute(params, wait, threadID, endpoint.GitHub())
 }
 
@@ -191,7 +191,7 @@ type WebhookWithTokenQueryBuilder interface {
 	// Delete Same as DeleteWebhook, except this call does not require authentication.
 	Delete() error
 
-	Execute(params *ExecuteWebhookParams, wait bool, threadID Snowflake, URLSuffix string) (*Message, error)
+	Execute(params *ExecuteWebhook, wait bool, threadID Snowflake, URLSuffix string) (*Message, error)
 }
 
 func (w webhookQueryBuilder) WithToken(token string) WebhookWithTokenQueryBuilder {
@@ -298,7 +298,7 @@ func (w webhookWithTokenQueryBuilder) Delete() error {
 //  Comment#2               For the webhook embed objects, you can set every field except type (it will be
 //                          rich regardless of if you try to set it), provider, video, and any height, width,
 //                          or proxy_url values for images.
-func (w webhookWithTokenQueryBuilder) Execute(params *ExecuteWebhookParams, wait bool, threadID Snowflake, URLSuffix string) (message *Message, err error) {
+func (w webhookWithTokenQueryBuilder) Execute(params *ExecuteWebhook, wait bool, threadID Snowflake, URLSuffix string) (message *Message, err error) {
 	if params == nil {
 		return nil, errors.New("params can not be nil")
 	}
@@ -317,7 +317,7 @@ func (w webhookWithTokenQueryBuilder) Execute(params *ExecuteWebhookParams, wait
 		contentType = "multipart/form-data"
 	}
 
-	urlparams := &execWebhookParams{
+	urlparams := &execWebhook{
 		Wait:     wait,
 		ThreadID: threadID,
 	}
@@ -343,7 +343,7 @@ func (w webhookWithTokenQueryBuilder) Execute(params *ExecuteWebhookParams, wait
 //
 //////////////////////////////////////////////////////
 
-// UpdateWebhookParams https://discord.com/developers/docs/resources/webhook#modify-webhook-json-params
+// UpdateWebhookParams str https://discord.com/developers/docs/resources/webhook#modify-webhook-json-params
 // Allows changing the name of the webhook, avatar and moving it to another channel. It also allows to resetting the
 // avatar by providing a nil to SetAvatar.
 //


### PR DESCRIPTION
I believe the Params suffix is there for historical reasons, I don't currently see a need for it and I'll mark the Params suffix as deprecated