### PR TITLE
Adds communication_disabled_until to support user timeouts

### DIFF
--- a/guild.go
+++ b/guild.go
@@ -513,15 +513,16 @@ var _ DeepCopier = (*IntegrationAccount)(nil)
 
 // Member https://discord.com/developers/docs/resources/guild#guild-member-object
 type Member struct {
-	GuildID      Snowflake   `json:"guild_id,omitempty"`
-	User         *User       `json:"user"`
-	Nick         string      `json:"nick,omitempty"`
-	Roles        []Snowflake `json:"roles"`
-	JoinedAt     Time        `json:"joined_at,omitempty"`
-	PremiumSince Time        `json:"premium_since,omitempty"`
-	Deaf         bool        `json:"deaf"`
-	Mute         bool        `json:"mute"`
-	Pending      bool        `json:"pending"`
+	GuildID                    Snowflake   `json:"guild_id,omitempty"`
+	User                       *User       `json:"user"`
+	Nick                       string      `json:"nick,omitempty"`
+	Roles                      []Snowflake `json:"roles"`
+	JoinedAt                   Time        `json:"joined_at,omitempty"`
+	PremiumSince               Time        `json:"premium_since,omitempty"`
+	Deaf                       bool        `json:"deaf"`
+	Mute                       bool        `json:"mute"`
+	Pending                    bool        `json:"pending"`
+	CommunicationDisabledUntil Time        `json:"communication_disabled_until"`
 
 	// custom
 	UserID Snowflake `json:"-"`

--- a/member.go
+++ b/member.go
@@ -118,12 +118,13 @@ func (g guildMemberQueryBuilder) Update(params *UpdateMember) (*Member, error) {
 }
 
 type UpdateMember struct {
-	Nick                       *string      `json:"nick,omitempty"`
-	Roles                      *[]Snowflake `json:"roles,omitempty"`
-	Mute                       *bool        `json:"mute,omitempty"`
-	Deaf                       *bool        `json:"deaf,omitempty"`
-	ChannelID                  *Snowflake   `json:"channel_id,omitempty"`
-	CommunicationDisabledUntil *Time        `json:"communication_disabled_until,omitempty"`
+	Nick      *string      `json:"nick,omitempty"`
+	Roles     *[]Snowflake `json:"roles,omitempty"`
+	Mute      *bool        `json:"mute,omitempty"`
+	Deaf      *bool        `json:"deaf,omitempty"`
+	ChannelID *Snowflake   `json:"channel_id,omitempty"`
+	// CommunicationDisabledUntil defines when the user's timeout will expire and the user will be able to communicate in the guild again (up to 28 days in the future)
+	CommunicationDisabledUntil *Time `json:"communication_disabled_until,omitempty"`
 
 	AuditLogReason string `json:"-"`
 }

--- a/member.go
+++ b/member.go
@@ -118,11 +118,12 @@ func (g guildMemberQueryBuilder) Update(params *UpdateMember) (*Member, error) {
 }
 
 type UpdateMember struct {
-	Nick      *string      `json:"nick,omitempty"`
-	Roles     *[]Snowflake `json:"roles,omitempty"`
-	Mute      *bool        `json:"mute,omitempty"`
-	Deaf      *bool        `json:"deaf,omitempty"`
-	ChannelID *Snowflake   `json:"channel_id,omitempty"`
+	Nick                       *string      `json:"nick,omitempty"`
+	Roles                      *[]Snowflake `json:"roles,omitempty"`
+	Mute                       *bool        `json:"mute,omitempty"`
+	Deaf                       *bool        `json:"deaf,omitempty"`
+	ChannelID                  *Snowflake   `json:"channel_id,omitempty"`
+	CommunicationDisabledUntil *Time        `json:"communication_disabled_until,omitempty"`
 
 	AuditLogReason string `json:"-"`
 }


### PR DESCRIPTION
# Description

Adds support for user timeouts using `communication_disabled_until` field on guild member objects.

https://discord.com/developers/docs/resources/guild#guild-member-object
https://discord.com/developers/docs/resources/guild#modify-guild-member

## Breaking Change?

no

# Checklist:

- [x] I have performed a self-review of my own code
- [x] Commented complex situations or referenced the discord documentation
- [x] Updated documentation
- [x] Added/Updated unit tests
- [x] Added/Updated benchmarks (if this is a performance critical component)
