### PR TITLE
fix: allow CreateInteractionResponse.Data to continue being nil

### DIFF
--- a/interaction.go
+++ b/interaction.go
@@ -96,6 +96,10 @@ type CreateInteractionResponse struct {
 }
 
 func (res *CreateInteractionResponse) prepare() (postBody interface{}, contentType string, err error) {
+	if res.Data == nil {
+		return res, httd.ContentTypeJSON, nil
+	}
+
 	p := res.Data
 	// spoiler tag
 	if p.SpoilerTagContent && len(p.Content) > 0 {


### PR DESCRIPTION
# Description
<!--
Please include a summary of the PR. Do not create a PR into branch:develop unless there exist no branch for the next release.

eg. If the current release is v0.10, then you should create a PR for branch:release/v0.11. If the next release branch is not out/created yet, create an issue or make a draft PR that goes into develop and change it to the release branch later on. Don't worry, I'll try my best to make this easy for everyone.
-->

Previously in v0.33.0, `InteractionResponse.Data` could be `nil`, which worked for component interactions, which do not need to send data to discord in the interaction response; however, interaction responses that actually created messages with files were not supported.

In v0.34.0, that was alleviated; however now, `CreateInteractionResponse.Data` must not be `nil` in order for `CreateInteractionResponse.prepare()` to function properly, so this broke component interactions that sent properly `nil` data. I added a section to `CreateInteractionResponse.prepare()` that returns the data necessary for `CreateInteractionResponse.Data == nil` to work for component interactions as before.

If you take a look at the discord documentation on the [interaction response structure](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-response-structure), data is optional, so I think it makes sense if `CreateInteractionResponse.Data` continues to be `nil`.

## Breaking Change?
<!--
if this is a breaking change please write "yes" or "no".
-->
no

## Benchmarks
<!--
If this PR requires benchmarks (say it is an very dependent component or takes a lot of resources/use, use pprof if you need to) then the benchmarks are provided before and after such that we can make logical decisions.
Note that if you add a benchmark and find your solution to run slower, the code might still be valuable so your results are welcomed anyways!
If no benchmarks are needed, feel free to delete til paragraph.
-->

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] Commented complex situations or referenced the discord documentation
- [ ] Updated documentation
- [ ] Added/Updated unit tests
- [ ] Added/Updated benchmarks (if this is a performance critical component)
