### PR TITLE
fix: remove unused and broken channel id checks in webhook

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -58,16 +58,12 @@ type webhookQueryBuilder struct {
 	ctx       context.Context
 	flags     Flag
 	client    *Client
-	cid       Snowflake
 	webhookID Snowflake
 }
 
 func (w *webhookQueryBuilder) validate() error {
 	if w.client == nil {
 		return ErrMissingClientInstance
-	}
-	if w.cid.IsZero() {
-		return ErrMissingChannelID
 	}
 	if w.webhookID.IsZero() {
 		return ErrMissingWebhookID
@@ -204,7 +200,6 @@ type webhookWithTokenQueryBuilder struct {
 	ctx       context.Context
 	flags     Flag
 	client    *Client
-	cid       Snowflake
 	webhookID Snowflake
 	token     string
 }
@@ -212,9 +207,6 @@ type webhookWithTokenQueryBuilder struct {
 func (w *webhookWithTokenQueryBuilder) validate() error {
 	if w.client == nil {
 		return ErrMissingClientInstance
-	}
-	if w.cid.IsZero() {
-		return ErrMissingChannelID
 	}
 	if w.webhookID.IsZero() {
 		return ErrMissingWebhookID


### PR DESCRIPTION
# Description
<!--
Please include a summary of the PR. Do not create a PR into branch:develop unless there exist no branch for the next release.

eg. If the current release is v0.10, then you should create a PR for branch:release/v0.11. If the next release branch is not out/created yet, create an issue or make a draft PR that goes into develop and change it to the release branch later on. Don't worry, I'll try my best to make this easy for everyone.
-->

I've just realized that in #475 i've overseen the channel id check in validate when i updated Execute and other methods to use validate, once i further checked the actual implementation and discord docs, ChannelId is never actually needed when interacting with Webhooks in any way so i just went ahead and fully remove it so that Execute and other checks do not error anymore

## Breaking Change?
<!--
if this is a breaking change please write "yes" or "no".
-->
no

## Benchmarks
<!--
If this PR requires benchmarks (say it is an very dependent component or takes a lot of resources/use, use pprof if you need to) then the benchmarks are provided before and after such that we can make logical decisions.
Note that if you add a benchmark and find your solution to run slower, the code might still be valuable so your results are welcomed anyways!
If no benchmarks are needed, feel free to delete til paragraph.
-->

# Checklist:

- [x] I have performed a self-review of my own code
- [x] Commented complex situations or referenced the discord documentation
- [x] Updated documentation
- [x] Added/Updated unit tests
- [x] Added/Updated benchmarks (if this is a performance critical component)
