### PR TITLE
feat: Add flags field to CreateInteractionResponseData

### DIFF
--- a/interaction.go
+++ b/interaction.go
@@ -47,13 +47,6 @@ const (
 	InteractionCallbackUpdateMessage
 )
 
-type InteractionMessageFlag uint
-
-const (
-	InteractionMessageFlagSuppressEmbeds InteractionMessageFlag = 1 << 2
-	InteractionMessageFlagEphemeral      InteractionMessageFlag = 1 << 6
-)
-
 // ApplicationCommandInteractionDataResolved
 // https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure
 type ApplicationCommandInteractionDataResolved struct {
@@ -84,13 +77,13 @@ type MessageInteraction struct {
 }
 
 type CreateInteractionResponseData struct {
-	Content         string                 `json:"content"`
-	Tts             bool                   `json:"tts,omitempty"`
-	Embeds          []*Embed               `json:"embeds,omitempty"`
-	Components      []*MessageComponent    `json:"components"`
-	Attachments     []*Attachment          `json:"attachments"`
-	AllowedMentions *AllowedMentions       `json:"allowed_mentions,omitempty"`
-	Flags           InteractionMessageFlag `json:"flags,omitempty"`
+	Content         string              `json:"content"`
+	Tts             bool                `json:"tts,omitempty"`
+	Embeds          []*Embed            `json:"embeds,omitempty"`
+	Components      []*MessageComponent `json:"components"`
+	Attachments     []*Attachment       `json:"attachments"`
+	AllowedMentions *AllowedMentions    `json:"allowed_mentions,omitempty"`
+	Flags           MessageFlag         `json:"flags,omitempty"` // Only SUPPRESS_EMBEDS and EPHEMERAL flags allowed.
 
 	Files []CreateMessageFile `json:"-"`
 

--- a/interaction.go
+++ b/interaction.go
@@ -47,6 +47,13 @@ const (
 	InteractionCallbackUpdateMessage
 )
 
+type InteractionMessageFlag uint
+
+const (
+	InteractionMessageFlagSuppressEmbeds InteractionMessageFlag = 1 << 2
+	InteractionMessageFlagEphemeral      InteractionMessageFlag = 1 << 6
+)
+
 // ApplicationCommandInteractionDataResolved
 // https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure
 type ApplicationCommandInteractionDataResolved struct {
@@ -77,12 +84,13 @@ type MessageInteraction struct {
 }
 
 type CreateInteractionResponseData struct {
-	Content         string              `json:"content"`
-	Tts             bool                `json:"tts,omitempty"`
-	Embeds          []*Embed            `json:"embeds,omitempty"`
-	Components      []*MessageComponent `json:"components"`
-	Attachments     []*Attachment       `json:"attachments"`
-	AllowedMentions *AllowedMentions    `json:"allowed_mentions,omitempty"`
+	Content         string                 `json:"content"`
+	Tts             bool                   `json:"tts,omitempty"`
+	Embeds          []*Embed               `json:"embeds,omitempty"`
+	Components      []*MessageComponent    `json:"components"`
+	Attachments     []*Attachment          `json:"attachments"`
+	AllowedMentions *AllowedMentions       `json:"allowed_mentions,omitempty"`
+	Flags           InteractionMessageFlag `json:"flags,omitempty"`
 
 	Files []CreateMessageFile `json:"-"`
 


### PR DESCRIPTION
# Description
This adds the flags field to the CreateInteractionResponseData struct as per Discord docs: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-messages

## Breaking Change?
no

# Checklist:

- [x] I have performed a self-review of my own code
- [x] Commented complex situations or referenced the discord documentation
- [ ] Updated documentation
- [ ] Added/Updated unit tests
- [ ] Added/Updated benchmarks (if this is a performance critical component)
