### PR TITLE
fix: Updated type for `session.EditInteractionResponse`

### DIFF
--- a/client.go
+++ b/client.go
@@ -524,7 +524,7 @@ func (ih *internalHandlers) saveApplicationID(_ Session, evt *Ready) {
 //
 //////////////////////////////////////////////////////
 
-func (c *Client) EditInteractionResponse(ctx context.Context, interaction *InteractionCreate, message *Message) error {
+func (c *Client) EditInteractionResponse(ctx context.Context, interaction *InteractionCreate, message *UpdateMessage) error {
 	endpoint := fmt.Sprintf("/webhooks/%d/%s/messages/@original", interaction.ApplicationID, interaction.Token)
 	req := &httd.Request{
 		Endpoint:    endpoint,

--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"sync"
@@ -525,15 +526,21 @@ func (ih *internalHandlers) saveApplicationID(_ Session, evt *Ready) {
 //////////////////////////////////////////////////////
 
 func (c *Client) EditInteractionResponse(ctx context.Context, interaction *InteractionCreate, message *UpdateMessage) error {
+	postBody, contentType, err := message.prepare()
+	if err != nil {
+		return err
+	}
+
 	endpoint := fmt.Sprintf("/webhooks/%d/%s/messages/@original", interaction.ApplicationID, interaction.Token)
 	req := &httd.Request{
 		Endpoint:    endpoint,
 		Method:      "PATCH",
-		Body:        message,
+		Body:        postBody,
 		Ctx:         ctx,
-		ContentType: httd.ContentTypeJSON,
+		ContentType: contentType,
 	}
-	_, _, err := c.req.Do(ctx, req)
+	_, _, err = c.req.Do(ctx, req)
+	log.Printf("Error: %v", err)
 	return err
 }
 

--- a/client.go
+++ b/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"sync"
@@ -540,7 +539,6 @@ func (c *Client) EditInteractionResponse(ctx context.Context, interaction *Inter
 		ContentType: contentType,
 	}
 	_, _, err = c.req.Do(ctx, req)
-	log.Printf("Error: %v", err)
 	return err
 }
 

--- a/deprecated.rest-struct-params.go
+++ b/deprecated.rest-struct-params.go
@@ -33,9 +33,6 @@ type GetMessagesParams = GetMessages
 // Deprecated: use DeleteMessages
 type DeleteMessagesParams = DeleteMessages
 
-// Deprecated: use CreateMessageFile
-type CreateMessageFileParams = CreateMessageFile
-
 // Deprecated: use CreateMessage
 type CreateMessageParams = CreateMessage
 

--- a/events.go
+++ b/events.go
@@ -301,7 +301,7 @@ type InteractionCreate struct {
 	ShardID       uint                               `json:"-"`
 }
 
-func (itc *InteractionCreate) Edit(ctx context.Context, session Session, response *Message) error {
+func (itc *InteractionCreate) Edit(ctx context.Context, session Session, response *UpdateMessage) error {
 	return session.EditInteractionResponse(ctx, itc, response)
 }
 

--- a/message.go
+++ b/message.go
@@ -5,10 +5,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/andersfylling/disgord/json"
 	"mime/multipart"
 	"net/http"
 	"strings"
+
+	"github.com/andersfylling/disgord/json"
 
 	"github.com/andersfylling/disgord/internal/endpoint"
 	"github.com/andersfylling/disgord/internal/httd"
@@ -488,10 +489,10 @@ func (m messageQueryBuilder) Update(params *UpdateMessage) (*Message, error) {
 }
 
 type UpdateMessage struct {
-	Content *string                  `json:"content,omitempty"`
-	Embeds  *[]*Embed                `json:"embeds,omitempty"`
-	Flags   *MessageFlag             `json:"flags,omitempty"`
-	File    *CreateMessageFileParams `json:"-"`
+	Content *string            `json:"content,omitempty"`
+	Embeds  *[]*Embed          `json:"embeds,omitempty"`
+	Flags   *MessageFlag       `json:"flags,omitempty"`
+	File    *CreateMessageFile `json:"-"`
 	// PayloadJSON *string `json:"payload_json,omitempty"`
 	AllowedMentions *AllowedMentions     `json:"allowed_mentions,omitempty"`
 	Components      *[]*MessageComponent `json:"components,omitempty"`

--- a/session.go
+++ b/session.go
@@ -34,7 +34,7 @@ type Session interface {
 	Pool() *pools
 
 	ClientQueryBuilder
-	EditInteractionResponse(ctx context.Context, interaction *InteractionCreate, message *Message) error
+	EditInteractionResponse(ctx context.Context, interaction *InteractionCreate, message *UpdateMessage) error
 	SendInteractionResponse(context context.Context, interaction *InteractionCreate, data *CreateInteractionResponse) error
 
 	UpdateStatus(s *UpdateStatusPayload) error


### PR DESCRIPTION
Updated type for `session.EditInteractionResponse`from Message to UpdateMessage, removed deprecated type definition

# Description
https://github.com/andersfylling/disgord/issues/496

closes #496

## Breaking Change?
yes

## Benchmarks
N/A

# Checklist:
- [x] I have performed a self-review of my own code
- [  ] Commented complex situations or referenced the discord documentation
- [  ] Updated documentation
- [  ] Added/Updated unit tests
- [  ] Added/Updated benchmarks (if this is a performance critical component)
