### PR TITLE
feat: text input components aka modals

### DIFF
--- a/interaction.go
+++ b/interaction.go
@@ -45,6 +45,8 @@ const (
 	InteractionCallbackDeferredChannelMessageWithSource
 	InteractionCallbackDeferredUpdateMessage
 	InteractionCallbackUpdateMessage
+	InteractionCallbackApplicationCommandAutocompleteResult
+	InteractionCallbackModal
 )
 
 // ApplicationCommandInteractionDataResolved

--- a/message.go
+++ b/message.go
@@ -99,6 +99,15 @@ const (
 	MessageComponentActionRow
 	MessageComponentButton
 	MessageComponentSelectMenu
+	MessageComponentTextInput
+)
+
+type TextInputStyle = int
+
+const (
+	_ TextInputStyle = iota
+	Short
+	Paragraph
 )
 
 type ButtonStyle = int
@@ -113,8 +122,9 @@ const (
 )
 
 type MessageComponent struct {
+	Title       string               `json:"title"`
 	Type        MessageComponentType `json:"type"`
-	Style       ButtonStyle          `json:"style"`
+	Style       int                  `json:"style"`
 	Label       string               `json:"label"`
 	Emoji       *Emoji               `json:"emoji"`
 	CustomID    string               `json:"custom_id"`


### PR DESCRIPTION
# Description
<!--
Please include a summary of the PR. Do not create a PR into branch:develop unless there exist no branch for the next release.

eg. If the current release is v0.10, then you should create a PR for branch:release/v0.11. If the next release branch is not out/created yet, create an issue or make a draft PR that goes into develop and change it to the release branch later on. Don't worry, I'll try my best to make this easy for everyone.
-->
I extended existing message component types to allow the creation of text input components, also known as Modals.

[Text Input Ref](https://discord.com/developers/docs/interactions/message-components#text-inputs)

## Breaking Change?
<!--
if this is a breaking change please write "yes" or "no".
-->
Yes.

I needed to change the type of `MessageComponent.Style` from `ButtonStyle` to `int` because `MessageComponent.Style` is reused for `TextInputStyle`, which uses some of the integers as `ButtonStyle`.

## Benchmarks
<!--
If this PR requires benchmarks (say it is an very dependent component or takes a lot of resources/use, use pprof if you need to) then the benchmarks are provided before and after such that we can make logical decisions.
Note that if you add a benchmark and find your solution to run slower, the code might still be valuable so your results are welcomed anyways!
If no benchmarks are needed, feel free to delete til paragraph.
-->

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] Commented complex situations or referenced the discord documentation
- [ ] Updated documentation
- [ ] Added/Updated unit tests
- [ ] Added/Updated benchmarks (if this is a performance critical component)
