### PR TITLE
feat: move to api v10

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -1262,7 +1262,7 @@ type CreateThreadWithoutMessage struct {
 	AutoArchiveDuration AutoArchiveDurationTime `json:"auto_archive_duration,omitempty"`
 	// In API v9, type defaults to PRIVATE_THREAD in order to match the behavior when
 	// thread documentation was first published. In API v10 this will be changed to be a required field, with no default.
-	Type             ChannelType `json:"type,omitempty"`
+	Type             ChannelType `json:"type"`
 	Invitable        bool        `json:"invitable,omitempty"`
 	RateLimitPerUser int         `json:"rate_limit_per_user,omitempty"`
 

--- a/intents_gen.go
+++ b/intents_gen.go
@@ -26,6 +26,7 @@ const (
 	IntentGuildVoiceStates       = gateway.IntentGuildVoiceStates
 	IntentGuildWebhooks          = gateway.IntentGuildWebhooks
 	IntentGuilds                 = gateway.IntentGuilds
+	IntentMessageContent         = gateway.IntentMessageContent
 )
 
 func AllIntents() Intent {
@@ -50,6 +51,7 @@ func AllIntentsExcept(exceptions ...Intent) Intent {
 		IntentGuildVoiceStates:       0,
 		IntentGuildWebhooks:          0,
 		IntentGuilds:                 0,
+		IntentMessageContent:         0,
 	}
 
 	for i := range exceptions {

--- a/internal/constant/communication.go
+++ b/internal/constant/communication.go
@@ -1,7 +1,7 @@
 package constant
 
 // DiscordVersion API version
-const DiscordVersion = 9
+const DiscordVersion = 10
 
 // JSONEncoding the json encoding identifier
 const JSONEncoding = "json"

--- a/internal/endpoint/channels.go
+++ b/internal/endpoint/channels.go
@@ -116,11 +116,6 @@ func ChannelThreadMemberUser(channelID, userID fmt.Stringer) string {
 	return ChannelThreadMembers(channelID) + "/" + userID.String()
 }
 
-// ChannelThreadsActive ...
-func ChannelThreadsActive(channelID fmt.Stringer) string {
-	return ChannelThreads(channelID) + active
-}
-
 // ChannelThreadsArchivedPublic ...
 func ChannelThreadsArchivedPublic(channelID fmt.Stringer) string {
 	return ChannelThreads(channelID) + archived + public

--- a/internal/gateway/intents.go
+++ b/internal/gateway/intents.go
@@ -77,7 +77,7 @@ const (
 	IntentDirectMessages
 	IntentDirectMessageReactions
 	IntentDirectMessageTyping
-	_
+	IntentMessageContent
 	IntentGuildScheduledEvents
 )
 
@@ -113,6 +113,8 @@ func intentName(intent Intent) string {
 		return "DirectMessageReactions"
 	case IntentDirectMessageTyping:
 		return "DirectMessageTyping"
+	case IntentMessageContent:
+		return "MessageContent"
 	default:
 		return ""
 	}

--- a/internal/httd/client.go
+++ b/internal/httd/client.go
@@ -101,7 +101,7 @@ func (c *Client) BucketGrouping() (group map[string][]string) {
 // SupportsDiscordAPIVersion check if a given discord api version is supported by this package.
 func SupportsDiscordAPIVersion(version int) bool {
 	supports := []int{
-		9,
+		10,
 	}
 
 	var supported bool


### PR DESCRIPTION
# Description
<!--
Please include a summary of the PR. Do not create a PR into branch:develop unless there exist no branch for the next release.

eg. If the current release is v0.10, then you should create a PR for branch:release/v0.11. If the next release branch is not out/created yet, create an issue or make a draft PR that goes into develop and change it to the release branch later on. Don't worry, I'll try my best to make this easy for everyone.
-->

Made changes to go to API v10. Nothing too major it seems.

[Here](https://github.com/discord/discord-api-docs/discussions/4510) are some of the most recent API v10 changes.

It looks like the `X-Audit-Log-Reason` header enforcement is already here, so I don't think anything needs to happen for that change.

## Breaking Change?
<!--
if this is a breaking change please write "yes" or "no".
-->
no

## Benchmarks
<!--
If this PR requires benchmarks (say it is an very dependent component or takes a lot of resources/use, use pprof if you need to) then the benchmarks are provided before and after such that we can make logical decisions.
Note that if you add a benchmark and find your solution to run slower, the code might still be valuable so your results are welcomed anyways!
If no benchmarks are needed, feel free to delete til paragraph.
-->

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] Commented complex situations or referenced the discord documentation
- [ ] Updated documentation
- [ ] Added/Updated unit tests
- [ ] Added/Updated benchmarks (if this is a performance critical component)
