### PR TITLE
fix: API does not accept empty string as null after update

### DIFF
--- a/message.go
+++ b/message.go
@@ -127,7 +127,7 @@ type MessageComponent struct {
 	Label       string               `json:"label"`
 	Emoji       *Emoji               `json:"emoji"`
 	CustomID    string               `json:"custom_id"`
-	Url         *string              `json:"url"`
+	Url         string               `json:"url,omitempty"`
 	Disabled    bool                 `json:"disabled"`
 	Components  []*MessageComponent  `json:"components,omitempty"`
 	Options     []*SelectMenuOption  `json:"options,omitempty"`

--- a/message.go
+++ b/message.go
@@ -127,7 +127,7 @@ type MessageComponent struct {
 	Label       string               `json:"label"`
 	Emoji       *Emoji               `json:"emoji"`
 	CustomID    string               `json:"custom_id"`
-	Url         string               `json:"url"`
+	Url         *string              `json:"url"`
 	Disabled    bool                 `json:"disabled"`
 	Components  []*MessageComponent  `json:"components,omitempty"`
 	Options     []*SelectMenuOption  `json:"options,omitempty"`


### PR DESCRIPTION
Without this change, it is not possible to send any message with non-link buttons

# Description
<!--
Please include a summary of the PR. Do not create a PR into branch:develop unless there exist no branch for the next release.

eg. If the current release is v0.10, then you should create a PR for branch:release/v0.11. If the next release branch is not out/created yet, create an issue or make a draft PR that goes into develop and change it to the release branch later on. Don't worry, I'll try my best to make this easy for everyone.
-->

## Breaking Change?
<!--
if this is a breaking change please write "yes" or "no".
-->
no

## Benchmarks
<!--
If this PR requires benchmarks (say it is an very dependent component or takes a lot of resources/use, use pprof if you need to) then the benchmarks are provided before and after such that we can make logical decisions.
Note that if you add a benchmark and find your solution to run slower, the code might still be valuable so your results are welcomed anyways!
If no benchmarks are needed, feel free to delete til paragraph.
-->

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] Commented complex situations or referenced the discord documentation
- [ ] Updated documentation
- [ ] Added/Updated unit tests
- [ ] Added/Updated benchmarks (if this is a performance critical component)
