### PR TITLE
feat: get/list commands, bulk set & fix update/delete

### DIFF
--- a/application_command.go
+++ b/application_command.go
@@ -63,29 +63,46 @@ type GuildApplicationCommandPermissions struct {
 }
 
 type ApplicationCommand struct {
-	ID                Snowflake                   `json:"id"`
-	Type              ApplicationCommandType      `json:"type"`
-	ApplicationID     Snowflake                   `json:"application_id"`
-	GuildID           Snowflake                   `json:"guild_id"`
-	Name              string                      `json:"name"`
-	Description       string                      `json:"description"`
-	Options           []*ApplicationCommandOption `json:"options"`
-	DefaultPermission bool                        `json:"default_permission,omitempty"`
+	ID                       Snowflake                   `json:"id"`
+	Type                     ApplicationCommandType      `json:"type,omitempty"`
+	ApplicationID            Snowflake                   `json:"application_id"`
+	GuildID                  Snowflake                   `json:"guild_id,omitempty"`
+	Name                     string                      `json:"name"`
+	NameLocalizations        map[string]string           `json:"name_localization,omitempty"`
+	Description              string                      `json:"description"`
+	DescriptionLocalizations map[string]string           `json:"description_localization,omitempty"`
+	Options                  []*ApplicationCommandOption `json:"options,omitempty"`
+	DefaultMemberPermissions *PermissionBit              `json:"default_member_permissions,omitempty"`
+	DMPermission             *bool                       `json:"dm_permission,omitempty"` // Global only.
+	DefaultPermission        bool                        `json:"default_permission,omitempty"`
+	NSFW                     bool                        `json:"nsfw,omitempty"`
+	Version                  Snowflake                   `json:"version,omitempty"`
 }
 
 type CreateApplicationCommand struct {
-	Name              string                      `json:"name"`
-	Description       string                      `json:"description"`
-	Type              ApplicationCommandType      `json:"type,omitempty"`
-	Options           []*ApplicationCommandOption `json:"options,omitempty"`
-	DefaultPermission bool                        `json:"default_permission,omitempty"`
+	Name                     string                      `json:"name"`
+	NameLocalizations        map[string]string           `json:"name_localization,omitempty"`
+	Description              string                      `json:"description,omitempty"`
+	DescriptionLocalizations map[string]string           `json:"description_localization,omitempty"`
+	Type                     ApplicationCommandType      `json:"type,omitempty"`
+	Options                  []*ApplicationCommandOption `json:"options,omitempty"`
+	DMPermission             *bool                       `json:"dm_permission,omitempty"`
+	DefaultMemberPermissions *PermissionBit              `json:"default_member_permissions,omitempty"`
+	DefaultPermission        bool                        `json:"default_permission,omitempty"`
+	NSFW                     *bool                       `json:"nsfw,omitempty"`
 }
 
 type UpdateApplicationCommand struct {
-	Name              *string                      `json:"name,omitempty"`
-	DefaultPermission *bool                        `json:"default_permission,omitempty"`
-	Description       *string                      `json:"description,omitempty"`
-	Options           *[]*ApplicationCommandOption `json:"options,omitempty"`
+	Name                     *string                      `json:"name,omitempty"`
+	NameLocalizations        *map[string]string           `json:"name_localization,omitempty"`
+	Description              *string                      `json:"description,omitempty"`
+	DescriptionLocalizations *map[string]string           `json:"description_localization,omitempty"`
+	Type                     *ApplicationCommandType      `json:"type,omitempty"`
+	Options                  *[]*ApplicationCommandOption `json:"options,omitempty"`
+	DMPermission             *bool                        `json:"dm_permission,omitempty"` // Global only.
+	DefaultMemberPermissions *PermissionBit               `json:"default_member_permissions,omitempty"`
+	DefaultPermission        *bool                        `json:"default_permission,omitempty"`
+	NSFW                     *bool                        `json:"nsfw,omitempty"`
 }
 
 type ApplicationCommandQueryBuilder interface {
@@ -95,9 +112,12 @@ type ApplicationCommandQueryBuilder interface {
 }
 
 type ApplicationCommandFunctions interface {
+	Get(commandId Snowflake) (*ApplicationCommand, error)
+	Commands() ([]*ApplicationCommand, error)
 	Delete(commandId Snowflake) error
 	Create(command *CreateApplicationCommand) error
 	Update(commandId Snowflake, command *UpdateApplicationCommand) error
+	BulkOverwrite(commands []*CreateApplicationCommand) error
 }
 
 type applicationCommandFunctions struct {
@@ -123,6 +143,51 @@ func applicationCommandFactory() interface{} {
 	return &ApplicationCommand{}
 }
 
+func (c *applicationCommandFunctions) Get(commandID Snowflake) (*ApplicationCommand, error) {
+	var endpoint string
+	if c.guildID == 0 {
+		endpoint = fmt.Sprintf("/applications/%d/commands/%d", c.applicationID(), commandID)
+	} else {
+		endpoint = fmt.Sprintf("/applications/%d/guilds/%d/commands/%d", c.applicationID(), c.guildID, commandID)
+	}
+
+	req := &httd.Request{
+		Endpoint:    endpoint,
+		Method:      http.MethodGet,
+		Ctx:         c.ctx,
+		ContentType: httd.ContentTypeJSON,
+	}
+
+	r := c.client.newRESTRequest(req, c.flags)
+	r.factory = applicationCommandFactory
+
+	return getApplicationCommand(r.Execute)
+}
+
+func (c *applicationCommandFunctions) Commands() ([]*ApplicationCommand, error) {
+	var endpoint string
+	if c.guildID == 0 {
+		endpoint = fmt.Sprintf("/applications/%d/commands", c.applicationID())
+	} else {
+		endpoint = fmt.Sprintf("/applications/%d/guilds/%d/commands", c.applicationID(), c.guildID)
+	}
+
+	req := &httd.Request{
+		Endpoint:    endpoint,
+		Method:      http.MethodGet,
+		Ctx:         c.ctx,
+		ContentType: httd.ContentTypeJSON,
+	}
+
+	r := c.client.newRESTRequest(req, c.flags)
+	r.factory = func() interface{} {
+		tmp := make([]*ApplicationCommand, 0)
+		return &tmp
+	}
+
+	return getApplicationCommands(r.Execute)
+}
+
 func (c *applicationCommandFunctions) Create(command *CreateApplicationCommand) error {
 	var endpoint string
 	if c.guildID == 0 {
@@ -130,14 +195,15 @@ func (c *applicationCommandFunctions) Create(command *CreateApplicationCommand) 
 	} else {
 		endpoint = fmt.Sprintf("/applications/%d/guilds/%d/commands", c.applicationID(), c.guildID)
 	}
-	ctx := c.ctx
+
 	req := &httd.Request{
 		Endpoint:    endpoint,
 		Method:      http.MethodPost,
 		Body:        command,
-		Ctx:         ctx,
+		Ctx:         c.ctx,
 		ContentType: httd.ContentTypeJSON,
 	}
+
 	r := c.client.newRESTRequest(req, c.flags)
 	r.factory = applicationCommandFactory
 	_, err := r.Execute()
@@ -146,20 +212,21 @@ func (c *applicationCommandFunctions) Create(command *CreateApplicationCommand) 
 
 func (c *applicationCommandFunctions) Update(commandID Snowflake, command *UpdateApplicationCommand) error {
 	var endpoint string
-	ctx := c.ctx
 
 	if c.guildID == 0 {
-		endpoint = fmt.Sprintf("applications/%d/commands/%d", c.applicationID(), commandID)
+		endpoint = fmt.Sprintf("/applications/%d/commands/%d", c.applicationID(), commandID)
 	} else {
-		endpoint = fmt.Sprintf("applications/%d/guilds/%d/commands/%d", c.applicationID(), c.guildID, commandID)
+		endpoint = fmt.Sprintf("/applications/%d/guilds/%d/commands/%d", c.applicationID(), c.guildID, commandID)
 	}
+
 	req := &httd.Request{
 		Endpoint:    endpoint,
 		Method:      http.MethodPatch,
 		Body:        command,
-		Ctx:         ctx,
+		Ctx:         c.ctx,
 		ContentType: httd.ContentTypeJSON,
 	}
+
 	r := c.client.newRESTRequest(req, c.flags)
 	r.factory = applicationCommandFactory
 	_, err := r.Execute()
@@ -168,21 +235,47 @@ func (c *applicationCommandFunctions) Update(commandID Snowflake, command *Updat
 
 func (c *applicationCommandFunctions) Delete(commandID Snowflake) error {
 	var endpoint string
-	ctx := c.ctx
 
 	if c.guildID == 0 {
-		endpoint = fmt.Sprintf("applications/%d/commands/%d", c.applicationID(), commandID)
+		endpoint = fmt.Sprintf("/applications/%d/commands/%d", c.applicationID(), commandID)
 	} else {
-		endpoint = fmt.Sprintf("applications/%d/guilds/%d/commands/%d", c.applicationID(), c.guildID, commandID)
+		endpoint = fmt.Sprintf("/applications/%d/guilds/%d/commands/%d", c.applicationID(), c.guildID, commandID)
 	}
+
 	req := &httd.Request{
 		Endpoint:    endpoint,
 		Method:      http.MethodDelete,
-		Ctx:         ctx,
+		Ctx:         c.ctx,
 		ContentType: httd.ContentTypeJSON,
 	}
+
 	r := c.client.newRESTRequest(req, c.flags)
 	r.factory = applicationCommandFactory
+	_, err := r.Execute()
+	return err
+}
+
+func (c *applicationCommandFunctions) BulkOverwrite(commands []*CreateApplicationCommand) error {
+	var endpoint string
+	if c.guildID == 0 {
+		endpoint = fmt.Sprintf("/applications/%d/commands", c.applicationID())
+	} else {
+		endpoint = fmt.Sprintf("/applications/%d/guilds/%d/commands", c.applicationID(), c.guildID)
+	}
+
+	req := &httd.Request{
+		Endpoint:    endpoint,
+		Method:      http.MethodPut,
+		Body:        commands,
+		Ctx:         c.ctx,
+		ContentType: httd.ContentTypeJSON,
+	}
+
+	r := c.client.newRESTRequest(req, c.flags)
+	r.factory = func() interface{} {
+		tmp := make([]*ApplicationCommand, 0)
+		return &tmp
+	}
 	_, err := r.Execute()
 	return err
 }
@@ -197,6 +290,7 @@ type applicationCommandQueryBuilder struct {
 func (q applicationCommandQueryBuilder) Guild(guildId Snowflake) ApplicationCommandFunctions {
 	return &applicationCommandFunctions{appID: q.appID, ctx: q.ctx, guildID: guildId, client: q.client, flags: q.flags}
 }
+
 func (q applicationCommandQueryBuilder) Global() ApplicationCommandFunctions {
 	return &applicationCommandFunctions{appID: q.appID, ctx: q.ctx, client: q.client, flags: q.flags}
 }


### PR DESCRIPTION
# Description

- Add `Get()` to the `ApplicationCommands` query builder, for fetching an individual application command.
- Add `Commands()` to the `ApplicationCommands` query builder, for fetching all application commands.
- Add `BulkOverwrite()` to the `ApplicationCommands` query builder, which allows overwriting all commands (global and guild still separate). Naming was defined by how it's described [here](https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-global-application-commands).
- Fix `Update()` and `Delete()` on `ApplicationCommands` query builder, where the generated URL didn't include `/` as the prefix, leading to a malformed request.

One of the **big items** I think with this change, is most users likely should shift to using `BulkOverwrite()`, which effectively defines all of their commands. The downside with the currently documented example is that if commands are added, then removed from the array, they never actually get removed from the application and/or guild.

There are three items I'm still not sure about.

- [ ] The naming of `Get()` for singular, and `Commands()` for listing. I skimmed through some of the other builders/methods and wasn't sure what was best for naming standards to differentiate 1 vs many.
- [ ] `Commands()` should probably accept an input, which allows the command list to include localized names and descriptions. I wasn't sure if:
   1. It should just default to enabling that (can't be much additional query data?)
   2. If an `Option` struct of some kind should be used. If this is the best option, not sure on best naming, as I don't see many of these types of structs across the project.
   3. If this should somehow be built into the query builder as an additional method.
- [ ] Should I update the command examples to use `BulkOverwrite()`?

## Breaking Change?

no

# Checklist:

- [x] I have performed a self-review of my own code
- [x] Commented complex situations or referenced the discord documentation
- [ ] Updated documentation
- [ ] Added/Updated unit tests
- [ ] Added/Updated benchmarks (if this is a performance critical component)
